### PR TITLE
pullpolicy: handle containers without a explicit imagePullPolicy set

### DIFF
--- a/score/score_test.go
+++ b/score/score_test.go
@@ -81,6 +81,14 @@ func TestPodContainerPullPolicyUndefined(t *testing.T) {
 	testExpectedScore(t, "pod-image-pullpolicy-undefined.yaml", "Container Image Pull Policy", 0)
 }
 
+func TestPodContainerPullPolicyUndefinedLatestTag(t *testing.T) {
+	testExpectedScore(t, "pod-image-pullpolicy-undefined-latest-tag.yaml", "Container Image Pull Policy", 10)
+}
+
+func TestPodContainerPullPolicyUndefinedNoTag(t *testing.T) {
+	testExpectedScore(t, "pod-image-pullpolicy-undefined-no-tag.yaml", "Container Image Pull Policy", 10)
+}
+
 func TestPodContainerPullPolicyNever(t *testing.T) {
 	testExpectedScore(t, "pod-image-pullpolicy-never.yaml", "Container Image Pull Policy", 0)
 }

--- a/score/testdata/pod-image-pullpolicy-undefined-latest-tag.yaml
+++ b/score/testdata/pod-image-pullpolicy-undefined-latest-tag.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-test-1
+spec:
+  containers:
+  - name: foobar
+    image: foo/bar:latest

--- a/score/testdata/pod-image-pullpolicy-undefined-no-tag.yaml
+++ b/score/testdata/pod-image-pullpolicy-undefined-no-tag.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-test-1
+spec:
+  containers:
+  - name: foobar
+    image: foo/bar


### PR DESCRIPTION
A typo in the issue description that recommended the policy "PullAlways" instead of "Always" was also fixed

Fixes #39