### PR TITLE
Recommend PodDisruptionBudget

### DIFF
--- a/score/disruptionbudget/disruptionbudget.go
+++ b/score/disruptionbudget/disruptionbudget.go
@@ -8,25 +8,41 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func hasMatching(budgets []policyv1beta1.PodDisruptionBudget, lables map[string]string) bool {
+	for _, budget := range budgets {
+		selector, err := metav1.LabelSelectorAsSelector(budget.Spec.Selector)
+		if err != nil {
+			panic(err)
+		}
+
+		if selector.Matches(mapLables(lables)) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func ScoreStatefulSetHas(budgets []policyv1beta1.PodDisruptionBudget) func(appsv1.StatefulSet) scorecard.TestScore {
 	return func(statefulset appsv1.StatefulSet) (score scorecard.TestScore) {
 		score.Name = "StatefulSet has PodDisruptionBudget"
 
-		hasMatching := false
-
-		for _, budget := range budgets {
-			selector, err := metav1.LabelSelectorAsSelector(budget.Spec.Selector)
-			if err != nil {
-				panic(err)
-			}
-
-			if selector.Matches(mapLables(statefulset.Spec.Template.Labels)) {
-				hasMatching = true
-				break
-			}
+		if hasMatching(budgets, statefulset.Spec.Template.Labels) {
+			score.Grade = scorecard.GradeAllOK
+		} else {
+			score.Grade = scorecard.GradeCritical
+			score.AddComment("", "No matching PodDisruptionBudget was found", "It's recommended to define a PodDisruptionBudget to avoid unexpected downtime during Kubernetes maintenance operations, such as when draining a node.")
 		}
 
-		if hasMatching {
+		return
+	}
+}
+
+func ScoreDeploymentHas(budgets []policyv1beta1.PodDisruptionBudget) func(appsv1.Deployment) scorecard.TestScore {
+	return func(deployment appsv1.Deployment) (score scorecard.TestScore) {
+		score.Name = "Deployment has PodDisruptionBudget"
+
+		if hasMatching(budgets, deployment.Spec.Template.Labels) {
 			score.Grade = scorecard.GradeAllOK
 		} else {
 			score.Grade = scorecard.GradeCritical

--- a/score/disruptionbudget/disruptionbudget.go
+++ b/score/disruptionbudget/disruptionbudget.go
@@ -1,0 +1,49 @@
+package disruptionbudget
+
+import (
+	"github.com/zegl/kube-score/scorecard"
+
+	appsv1 "k8s.io/api/apps/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ScoreStatefulSetHas(budgets []policyv1beta1.PodDisruptionBudget) func(appsv1.StatefulSet) scorecard.TestScore {
+	return func(statefulset appsv1.StatefulSet) (score scorecard.TestScore) {
+		score.Name = "StatefulSet has PodDisruptionBudget"
+
+		hasMatching := false
+
+		for _, budget := range budgets {
+			selector, err := metav1.LabelSelectorAsSelector(budget.Spec.Selector)
+			if err != nil {
+				panic(err)
+			}
+
+			if selector.Matches(mapLables(statefulset.Spec.Template.Labels)) {
+				hasMatching = true
+				break
+			}
+		}
+
+		if hasMatching {
+			score.Grade = scorecard.GradeAllOK
+		} else {
+			score.Grade = scorecard.GradeCritical
+			score.AddComment("", "No matching PodDisruptionBudget was found", "It's recommended to define a PodDisruptionBudget to avoid unexpected downtime during Kubernetes maintenance operations, such as when draining a node.")
+		}
+
+		return
+	}
+}
+
+type mapLables map[string]string
+
+func (m mapLables) Has(key string) bool {
+	_, ok := m[key]
+	return ok
+}
+
+func (m mapLables) Get(key string) string {
+	return m[key]
+}

--- a/score/poddisruptionbudget_test.go
+++ b/score/poddisruptionbudget_test.go
@@ -17,3 +17,19 @@ func TestStatefulSetPodDisruptionBudgetExpressionNoMatch(t *testing.T) {
 func TestStatefulSetPodDisruptionBudgetNoMatch(t *testing.T) {
 	testExpectedScore(t, "statefulset-poddisruptionbudget-no-match.yaml", "StatefulSet has PodDisruptionBudget", 1)
 }
+
+func TestDeploymentPodDisruptionBudgetMatches(t *testing.T) {
+	testExpectedScore(t, "deployment-poddisruptionbudget-matches.yaml", "Deployment has PodDisruptionBudget", 10)
+}
+
+func TestDeploymentPodDisruptionBudgetExpressionMatches(t *testing.T) {
+	testExpectedScore(t, "deployment-poddisruptionbudget-expression-matches.yaml", "Deployment has PodDisruptionBudget", 10)
+}
+
+func TestDeploymentPodDisruptionBudgetExpressionNoMatch(t *testing.T) {
+	testExpectedScore(t, "deployment-poddisruptionbudget-expression-no-match.yaml", "Deployment has PodDisruptionBudget", 1)
+}
+
+func TestDeploymentPodDisruptionBudgetNoMatch(t *testing.T) {
+	testExpectedScore(t, "deployment-poddisruptionbudget-no-match.yaml", "Deployment has PodDisruptionBudget", 1)
+}

--- a/score/poddisruptionbudget_test.go
+++ b/score/poddisruptionbudget_test.go
@@ -1,0 +1,19 @@
+package score
+
+import "testing"
+
+func TestStatefulSetPodDisruptionBudgetMatches(t *testing.T) {
+	testExpectedScore(t, "statefulset-poddisruptionbudget-matches.yaml", "StatefulSet has PodDisruptionBudget", 10)
+}
+
+func TestStatefulSetPodDisruptionBudgetExpressionMatches(t *testing.T) {
+	testExpectedScore(t, "statefulset-poddisruptionbudget-expression-matches.yaml", "StatefulSet has PodDisruptionBudget", 10)
+}
+
+func TestStatefulSetPodDisruptionBudgetExpressionNoMatch(t *testing.T) {
+	testExpectedScore(t, "statefulset-poddisruptionbudget-expression-no-match.yaml", "StatefulSet has PodDisruptionBudget", 1)
+}
+
+func TestStatefulSetPodDisruptionBudgetNoMatch(t *testing.T) {
+	testExpectedScore(t, "statefulset-poddisruptionbudget-no-match.yaml", "StatefulSet has PodDisruptionBudget", 1)
+}

--- a/score/score.go
+++ b/score/score.go
@@ -230,6 +230,10 @@ func Score(config Configuration) (*scorecard.Scorecard, error) {
 		disruptionbudget.ScoreStatefulSetHas(podDisruptionBudgets),
 	}
 
+	deploymentTests := []func(appsv1.Deployment) scorecard.TestScore{
+		disruptionbudget.ScoreDeploymentHas(podDisruptionBudgets),
+	}
+
 	scoreCard := scorecard.New()
 
 	for _, meta := range typeMetas {
@@ -271,6 +275,14 @@ func Score(config Configuration) (*scorecard.Scorecard, error) {
 		for _, test := range statefulSetTests {
 			score := test(statefulset)
 			score.AddMeta(statefulset.TypeMeta, statefulset.ObjectMeta)
+			scoreCard.Add(score)
+		}
+	}
+
+	for _, deployment := range deployments {
+		for _, test := range deploymentTests {
+			score := test(deployment)
+			score.AddMeta(deployment.TypeMeta, deployment.ObjectMeta)
 			scoreCard.Add(score)
 		}
 	}

--- a/score/testdata/deployment-poddisruptionbudget-expression-matches.yaml
+++ b/score/testdata/deployment-poddisruptionbudget-expression-matches.yaml
@@ -1,0 +1,25 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: app-budget
+spec:
+  minAvailable: 2
+  selector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values: [foo, foo1, foo2]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: statefulset-test-1
+spec:
+  template:
+    metadata:
+      labels:
+        app: foo
+    spec:
+      containers:
+      - name: foobar
+        image: foo:bar

--- a/score/testdata/deployment-poddisruptionbudget-expression-no-match.yaml
+++ b/score/testdata/deployment-poddisruptionbudget-expression-no-match.yaml
@@ -1,0 +1,25 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: app-budget
+spec:
+  minAvailable: 2
+  selector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values: ["not-foo", "not-foo2"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: statefulset-test-1
+spec:
+  template:
+    metadata:
+      labels:
+        app: foo
+    spec:
+      containers:
+      - name: foobar
+        image: foo:bar

--- a/score/testdata/deployment-poddisruptionbudget-matches.yaml
+++ b/score/testdata/deployment-poddisruptionbudget-matches.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: app-budget
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: foo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: statefulset-test-1
+spec:
+  template:
+    metadata:
+      labels:
+        app: foo
+    spec:
+      containers:
+      - name: foobar
+        image: foo:bar

--- a/score/testdata/deployment-poddisruptionbudget-no-match.yaml
+++ b/score/testdata/deployment-poddisruptionbudget-no-match.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: app-budget
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: not-foo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: statefulset-test-1
+spec:
+  template:
+    metadata:
+      labels:
+        app: foo
+    spec:
+      containers:
+      - name: foobar
+        image: foo:bar

--- a/score/testdata/statefulset-poddisruptionbudget-expression-matches.yaml
+++ b/score/testdata/statefulset-poddisruptionbudget-expression-matches.yaml
@@ -1,0 +1,25 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: app-budget
+spec:
+  minAvailable: 2
+  selector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values: [foo, foo1, foo2]
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: statefulset-test-1
+spec:
+  template:
+    metadata:
+      labels:
+        app: foo
+    spec:
+      containers:
+      - name: foobar
+        image: foo:bar

--- a/score/testdata/statefulset-poddisruptionbudget-expression-no-match.yaml
+++ b/score/testdata/statefulset-poddisruptionbudget-expression-no-match.yaml
@@ -1,0 +1,25 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: app-budget
+spec:
+  minAvailable: 2
+  selector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values: ["not-foo", "not-foo2"]
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: statefulset-test-1
+spec:
+  template:
+    metadata:
+      labels:
+        app: foo
+    spec:
+      containers:
+      - name: foobar
+        image: foo:bar

--- a/score/testdata/statefulset-poddisruptionbudget-matches.yaml
+++ b/score/testdata/statefulset-poddisruptionbudget-matches.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: app-budget
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: foo
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: statefulset-test-1
+spec:
+  template:
+    metadata:
+      labels:
+        app: foo
+    spec:
+      containers:
+      - name: foobar
+        image: foo:bar

--- a/score/testdata/statefulset-poddisruptionbudget-no-match.yaml
+++ b/score/testdata/statefulset-poddisruptionbudget-no-match.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: app-budget
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: not-foo
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: statefulset-test-1
+spec:
+  template:
+    metadata:
+      labels:
+        app: foo
+    spec:
+      containers:
+      - name: foobar
+        image: foo:bar


### PR DESCRIPTION
Cause a critical score if a StatefulSet or Deployment (both only `apps/v1`) does not have a `PodDisruptionBudget` (`policy/v1beta1`) set.

Fixes #43 
