### PR TITLE
service: ignore services of type ExternalName in the service-targets-pod test

### DIFF
--- a/score/service/service.go
+++ b/score/service/service.go
@@ -29,6 +29,12 @@ func ScoreServiceTargetsPod(pods []corev1.Pod, podspecers []ks.PodSpecer) func(c
 		score.Name = "Service Targets Pod"
 		score.ID = "service-targets-pod"
 
+		// Services of type ExternalName does not have a selector
+		if service.Spec.Type == corev1.ServiceTypeExternalName {
+			score.Grade = scorecard.GradeAllOK
+			return
+		}
+
 		hasMatch := false
 
 		for _, podLables := range podsInNamespace[service.Namespace] {

--- a/score/service_test.go
+++ b/score/service_test.go
@@ -41,3 +41,7 @@ func TestServiceTargetsPodDeploymentSameNamespace(t *testing.T) {
 func TestServiceTargetsPodDeploymentDifferentNamespace(t *testing.T) {
 	testExpectedScore(t, "service-target-deployment-different-namespace.yaml", "Service Targets Pod", 1)
 }
+
+func TestServiceExternalName(t *testing.T) {
+	testExpectedScore(t, "service-externalname.yaml", "Service Targets Pod", 10)
+}

--- a/score/testdata/service-externalname.yaml
+++ b/score/testdata/service-externalname.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wp-site
+  namespace: site
+spec:
+  externalName: wp.example.com
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  type: ExternalName


### PR DESCRIPTION
Fixes #53