### PR TITLE
parser: forward namespace names to pod template specs

### DIFF
--- a/parser/internal/deamonset.go
+++ b/parser/internal/deamonset.go
@@ -21,6 +21,7 @@ func (d Appsv1DaemonSet) GetObjectMeta() metav1.ObjectMeta {
 }
 
 func (d Appsv1DaemonSet) GetPodTemplateSpec() corev1.PodTemplateSpec {
+	d.Spec.Template.ObjectMeta.Namespace = d.ObjectMeta.Namespace
 	return d.Spec.Template
 }
 
@@ -37,6 +38,7 @@ func (d Appsv1beta2DaemonSet) GetObjectMeta() metav1.ObjectMeta {
 }
 
 func (d Appsv1beta2DaemonSet) GetPodTemplateSpec() corev1.PodTemplateSpec {
+	d.Spec.Template.ObjectMeta.Namespace = d.ObjectMeta.Namespace
 	return d.Spec.Template
 }
 
@@ -53,5 +55,6 @@ func (d Extensionsv1beta1DaemonSet) GetObjectMeta() metav1.ObjectMeta {
 }
 
 func (d Extensionsv1beta1DaemonSet) GetPodTemplateSpec() corev1.PodTemplateSpec {
+	d.Spec.Template.ObjectMeta.Namespace = d.ObjectMeta.Namespace
 	return d.Spec.Template
 }

--- a/parser/internal/deployment.go
+++ b/parser/internal/deployment.go
@@ -22,6 +22,7 @@ func (d Appsv1Deployment) GetObjectMeta() metav1.ObjectMeta {
 }
 
 func (d Appsv1Deployment) GetPodTemplateSpec() corev1.PodTemplateSpec {
+	d.Spec.Template.ObjectMeta.Namespace = d.ObjectMeta.Namespace
 	return d.Spec.Template
 }
 
@@ -38,6 +39,7 @@ func (d Appsv1beta1Deployment) GetObjectMeta() metav1.ObjectMeta {
 }
 
 func (d Appsv1beta1Deployment) GetPodTemplateSpec() corev1.PodTemplateSpec {
+	d.Spec.Template.ObjectMeta.Namespace = d.ObjectMeta.Namespace
 	return d.Spec.Template
 }
 
@@ -54,6 +56,7 @@ func (d Appsv1beta2Deployment) GetObjectMeta() metav1.ObjectMeta {
 }
 
 func (d Appsv1beta2Deployment) GetPodTemplateSpec() corev1.PodTemplateSpec {
+	d.Spec.Template.ObjectMeta.Namespace = d.ObjectMeta.Namespace
 	return d.Spec.Template
 }
 
@@ -70,5 +73,6 @@ func (d Extensionsv1beta1Deployment) GetObjectMeta() metav1.ObjectMeta {
 }
 
 func (d Extensionsv1beta1Deployment) GetPodTemplateSpec() corev1.PodTemplateSpec {
+	d.Spec.Template.ObjectMeta.Namespace = d.ObjectMeta.Namespace
 	return d.Spec.Template
 }

--- a/parser/internal/jobs.go
+++ b/parser/internal/jobs.go
@@ -20,6 +20,7 @@ func (d Batchv1Job) GetObjectMeta() metav1.ObjectMeta {
 }
 
 func (d Batchv1Job) GetPodTemplateSpec() corev1.PodTemplateSpec {
+	d.Spec.Template.ObjectMeta.Namespace = d.ObjectMeta.Namespace
 	return d.Spec.Template
 }
 
@@ -36,5 +37,6 @@ func (d Batchv1beta1CronJob) GetObjectMeta() metav1.ObjectMeta {
 }
 
 func (d Batchv1beta1CronJob) GetPodTemplateSpec() corev1.PodTemplateSpec {
+	d.Spec.JobTemplate.ObjectMeta.Namespace = d.ObjectMeta.Namespace
 	return d.Spec.JobTemplate.Spec.Template
 }

--- a/parser/internal/statefulset.go
+++ b/parser/internal/statefulset.go
@@ -21,6 +21,7 @@ func (s Appsv1StatefulSet) GetObjectMeta() metav1.ObjectMeta {
 }
 
 func (s Appsv1StatefulSet) GetPodTemplateSpec() corev1.PodTemplateSpec {
+	s.Spec.Template.ObjectMeta.Namespace = s.ObjectMeta.Namespace
 	return s.Spec.Template
 }
 
@@ -37,6 +38,7 @@ func (s Appsv1beta1StatefulSet) GetObjectMeta() metav1.ObjectMeta {
 }
 
 func (s Appsv1beta1StatefulSet) GetPodTemplateSpec() corev1.PodTemplateSpec {
+	s.Spec.Template.ObjectMeta.Namespace = s.ObjectMeta.Namespace
 	return s.Spec.Template
 }
 
@@ -53,5 +55,6 @@ func (s Appsv1beta2StatefulSet) GetObjectMeta() metav1.ObjectMeta {
 }
 
 func (s Appsv1beta2StatefulSet) GetPodTemplateSpec() corev1.PodTemplateSpec {
+	s.Spec.Template.ObjectMeta.Namespace = s.ObjectMeta.Namespace
 	return s.Spec.Template
 }

--- a/score/networkpolicy_test.go
+++ b/score/networkpolicy_test.go
@@ -31,3 +31,8 @@ func TestNetworkPolicyTargetsPodInDeployment(t *testing.T) {
 func TestNetworkPolicyTargetsPodNotMatching(t *testing.T) {
 	testExpectedScore(t, "networkpolicy-targets-pod-not-matching.yaml", "NetworkPolicy targets Pod", 1)
 }
+
+func TestNetworkPolicyNamespaceMatching(t *testing.T) {
+	testExpectedScore(t, "networkpolicy-deployment-matching.yaml", "NetworkPolicy targets Pod", 10)
+	testExpectedScore(t, "networkpolicy-deployment-matching.yaml", "Pod NetworkPolicy", 10)
+}

--- a/score/testdata/networkpolicy-deployment-matching.yaml
+++ b/score/testdata/networkpolicy-deployment-matching.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: testapp-netpol
+  namespace: testspace
+spec:
+  podSelector:
+    matchLabels:
+      app: foo
+  policyTypes:
+    - Egress
+    - Ingress
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: statefulset-test-1
+  namespace: testspace
+spec:
+  template:
+    metadata:
+      labels:
+        app: foo
+    spec:
+      containers:
+        - name: foobar
+          image: foo:bar


### PR DESCRIPTION
Network policies start by checking namespace that is empty for pod inside deployments. Without this network policies tests that have namespace tests as the pod namespace is empty and the first comparison fails.