### PR TITLE
goreleaser: update archive configuration

### DIFF
--- a/cmd/kube-score/.goreleaser.yml
+++ b/cmd/kube-score/.goreleaser.yml
@@ -7,13 +7,14 @@ builds:
   - windows
   goarch:
   - amd64
-archive:
-  replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
+archives:
+  - id: kube-score
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
The "archive" option is deprecated, and has been replaced by "archives"

See https://goreleaser.com/deprecations/#archive