### PR TITLE
cmd: ignore ignored tests when calculating the exit code

### DIFF
--- a/cmd/kube-score/main.go
+++ b/cmd/kube-score/main.go
@@ -157,9 +157,9 @@ Use "-" as filename to read from STDIN.`)
 	}
 
 	var exitCode int
-	if scoreCard.AnyBelowOrEqualToGrade(scorecard.GradeCritical) {
+	if scoreCard.AnyBelowOrEqualToGrade(scorecard.GradeCritical, ignoredTests) {
 		exitCode = 1
-	} else if *exitOneOnWarning && scoreCard.AnyBelowOrEqualToGrade(scorecard.Grade(*warningThreshold)) {
+	} else if *exitOneOnWarning && scoreCard.AnyBelowOrEqualToGrade(scorecard.Grade(*warningThreshold), ignoredTests) {
 		exitCode = 1
 	} else {
 		exitCode = 0

--- a/scorecard/scorecard.go
+++ b/scorecard/scorecard.go
@@ -35,9 +35,13 @@ func (s Scorecard) NewObject(typeMeta metav1.TypeMeta, objectMeta metav1.ObjectM
 	return o
 }
 
-func (s Scorecard) AnyBelowOrEqualToGrade(threshold Grade) bool {
+func (s Scorecard) AnyBelowOrEqualToGrade(threshold Grade, ignoredTests map[string]struct{}) bool {
 	for _, o := range s {
 		for _, s := range o.Checks {
+			if _, ok := ignoredTests[s.Check.ID]; ok {
+				continue
+			}
+
 			if s.Grade <= threshold {
 				return true
 			}


### PR DESCRIPTION
This fixes a bug introduced in #133 (never released).