### PR TITLE
security: inherit values from the PodSecurityContext

### DIFF
--- a/score/testdata/security-inherit-pod-security-context.yaml
+++ b/score/testdata/security-inherit-pod-security-context.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  labels:
+    app: test
+spec:
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      securityContext:
+        runAsGroup: 20000
+        runAsUser: 20000
+      containers:
+        - name: test
+          securityContext:
+            privileged: false
+            readOnlyRootFilesystem: true


### PR DESCRIPTION
This fixes #146 

```
RELNOTE: Values from PodSecurityContext are properly inherited to the container SecurityContext
```