### PR TITLE
config: allow creating optional tests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -8,4 +8,5 @@ type Configuration struct {
 	IgnoreContainerCpuLimitRequirement    bool
 	IgnoreContainerMemoryLimitRequirement bool
 	IgnoredTests                          map[string]struct{}
+	EnabledOptionalTests                  map[string]struct{}
 }

--- a/domain/kube-score.go
+++ b/domain/kube-score.go
@@ -15,6 +15,7 @@ type Check struct {
 	ID         string
 	TargetType string
 	Comment    string
+	Optional   bool
 }
 
 type BothMeta struct {


### PR DESCRIPTION
some scores can be are rather opinionated, and it should be possible to not run them by default

```
RELNOTE: add the `--enable-optional-test` CLI flag to allow adding opt-in only scores
```