### PR TITLE
docker: don't set ENTRYPOINT in helm based release

### DIFF
--- a/cmd/kube-score/helm.Dockerfile
+++ b/cmd/kube-score/helm.Dockerfile
@@ -16,4 +16,3 @@ RUN apk update && \
     apk add bash
 COPY --from=downloader /linux-amd64/helm /usr/bin/helm
 COPY kube-score /usr/bin/kube-score
-ENTRYPOINT ["/usr/bin/kube-score"]


### PR DESCRIPTION
The presense of ENTRYPOINT makes it unneccesarily complex to invocate helm,
which is the biggest usecase of this release mode.

```
RELNOTE: ENTRYPOINT is no longer set in the "-helm" container
```

This fixes #151 