### PR TITLE
install ca-certificates for alpine

### DIFF
--- a/cmd/kube-score/helm.Dockerfile
+++ b/cmd/kube-score/helm.Dockerfile
@@ -13,6 +13,6 @@ RUN apt-get update && \
 FROM alpine:3.4
 RUN apk update && \
     apk upgrade && \
-    apk add bash
+    apk add bash ca-certificates
 COPY --from=downloader /linux-amd64/helm /usr/bin/helm
 COPY kube-score /usr/bin/kube-score


### PR DESCRIPTION
The kube-score image with helm pre-installed is shipped without the ca-certificates installed.
This causes `helm init --client-only` to fail with
```
Error: error initializing: Looks like "https://kubernetes-charts.storage.googleapis.com" is not a valid chart repository or cannot be reached: Get https://kubernetes-charts.storage.googleapis.com/index.yaml: x509: certificate signed by unknown authority
```

Fixed by installing the `ca-certificates` bundle.

```
RELNOTE: Added `ca-certificates` to kube-score docker image with Helm pre-installed.
```
