### PR TITLE
adding feature for revisionHistoryLimit

### DIFF
--- a/score/revisionHistoryLimit/revisionHistoryLimit.go
+++ b/score/revisionHistoryLimit/revisionHistoryLimit.go
@@ -1,0 +1,65 @@
+package revisionHistoryLimit
+
+import (
+//	ks "github.com/zegl/kube-score/domain"
+	"github.com/zegl/kube-score/score/checks"
+//	"github.com/zegl/kube-score/score/internal"
+	"github.com/zegl/kube-score/scorecard"
+        appsv1 "k8s.io/api/apps/v1"
+//	corev1 "k8s.io/api/core/v1"
+//	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Register( allChecks *checks.Checks ) {
+        allChecks.RegisterDeploymentCheck( "Deployment sets revisionHistoryLimit", `Makes sure that all Deployments set a limit`, deploymentHas() )
+}
+
+func deploymentHas() func( appsv1.Deployment ) ( scorecard.TestScore, error ) {
+        return func( deployment appsv1.Deployment ) ( score scorecard.TestScore, err error ) {
+		limit := deployment.Spec.RevisionHistoryLimit
+                if limit != nil {
+			if *limit > 5 {
+                                score.Grade = scorecard.GradeAlmostOK
+				score.AddComment( "", "revisionHistoryLimit greater than 5", "It's recommended to define a revisionHistoryLimit below 5 to avoid data storage impact" )
+			} else {
+				score.Grade = scorecard.GradeAllOK
+			}
+			return
+                } else {
+                        score.Grade = scorecard.GradeCritical
+                        score.AddComment( "", "No revisionHistoryLimit Configuration was found", "It's recommended to define a revisionHistoryLimit below 5 to avoid data storage impact" )
+                        return
+                }
+		return
+
+/*
+                        } else {
+                                score.Grade = scorecard.GradeAlmostOK
+                                score.AddComment("", "Pod has the same readiness and liveness probe", "It's recommended to have different probes for the two different purposes.")
+                        }
+*/
+
+/*
+                if deployment.Spec.Replicas != nil && *deployment.Spec.Replicas < 2 {
+                        score.Grade = scorecard.GradeAllOK
+                        score.AddComment("", "Skipped", "Skipped because the deployment has less than 2 replicas")
+                        return
+                }
+
+                match, matchErr := "hello", nil
+                if matchErr != nil {
+                        err = matchErr
+                        return
+                }
+
+                if match {
+                        score.Grade = scorecard.GradeAllOK
+                } else {
+                        score.Grade = scorecard.GradeCritical
+                        score.AddComment("", "No matching PodDisruptionBudget was found", "It's recommended to define a PodDisruptionBudget to avoid unexpected downtime during Kubernetes maintenance operations, such as when draining a node.")
+                }
+
+                return
+*/
+        }
+}

--- a/score/revisionHistoryLimit/revisionHistoryLimit.go
+++ b/score/revisionHistoryLimit/revisionHistoryLimit.go
@@ -1,13 +1,9 @@
 package revisionHistoryLimit
 
 import (
-//	ks "github.com/zegl/kube-score/domain"
 	"github.com/zegl/kube-score/score/checks"
-//	"github.com/zegl/kube-score/score/internal"
 	"github.com/zegl/kube-score/scorecard"
         appsv1 "k8s.io/api/apps/v1"
-//	corev1 "k8s.io/api/core/v1"
-//	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Register( allChecks *checks.Checks ) {
@@ -31,35 +27,5 @@ func deploymentHas() func( appsv1.Deployment ) ( scorecard.TestScore, error ) {
                         return
                 }
 		return
-
-/*
-                        } else {
-                                score.Grade = scorecard.GradeAlmostOK
-                                score.AddComment("", "Pod has the same readiness and liveness probe", "It's recommended to have different probes for the two different purposes.")
-                        }
-*/
-
-/*
-                if deployment.Spec.Replicas != nil && *deployment.Spec.Replicas < 2 {
-                        score.Grade = scorecard.GradeAllOK
-                        score.AddComment("", "Skipped", "Skipped because the deployment has less than 2 replicas")
-                        return
-                }
-
-                match, matchErr := "hello", nil
-                if matchErr != nil {
-                        err = matchErr
-                        return
-                }
-
-                if match {
-                        score.Grade = scorecard.GradeAllOK
-                } else {
-                        score.Grade = scorecard.GradeCritical
-                        score.AddComment("", "No matching PodDisruptionBudget was found", "It's recommended to define a PodDisruptionBudget to avoid unexpected downtime during Kubernetes maintenance operations, such as when draining a node.")
-                }
-
-                return
-*/
         }
 }

--- a/score/revisionHistoryLimit_test.go
+++ b/score/revisionHistoryLimit_test.go
@@ -1,0 +1,13 @@
+package score
+
+import "testing"
+
+func TestRevisionHistoryLimit(t *testing.T) {
+	testExpectedScore(t, "deployment-sets-revisionhistorylimit.yaml", "Deployment sets revisionHistoryLimit", 10)
+}
+func TestNoRevisionHistoryLimit(t *testing.T) {
+        testExpectedScore(t, "deployment-sets-no-revisionhistorylimit.yaml", "Deployment sets revisionHistoryLimit", 1)
+}
+func TestHighRevisionHistoryLimit(t *testing.T) {
+        testExpectedScore(t, "deployment-sets-high-revisionhistorylimit.yaml", "Deployment sets revisionHistoryLimit", 7)
+}

--- a/score/score.go
+++ b/score/score.go
@@ -12,6 +12,7 @@ import (
 	"github.com/zegl/kube-score/score/meta"
 	"github.com/zegl/kube-score/score/networkpolicy"
 	"github.com/zegl/kube-score/score/probes"
+	"github.com/zegl/kube-score/score/revisionHistoryLimit"
 	"github.com/zegl/kube-score/score/security"
 	"github.com/zegl/kube-score/score/service"
 	"github.com/zegl/kube-score/score/stable"
@@ -29,6 +30,7 @@ func RegisterAllChecks(allObjects ks.AllTypes, cnf config.Configuration) *checks
 	disruptionbudget.Register(allChecks, allObjects)
 	networkpolicy.Register(allChecks, allObjects, allObjects, allObjects)
 	probes.Register(allChecks, allObjects)
+	revisionHistoryLimit.Register(allChecks)
 	security.Register(allChecks)
 	service.Register(allChecks, allObjects, allObjects)
 	stable.Register(allChecks)

--- a/score/testdata/deployment-sets-high-revisionhistorylimit.yaml
+++ b/score/testdata/deployment-sets-high-revisionhistorylimit.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-service
+spec:
+  revisionHistoryLimit: 6
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-service
+  template:
+    metadata:
+      annotations:
+        container.apparmor.security.beta.kubernetes.io: localhost/docker-default
+      labels:
+        app: my-service
+    spec:
+      containers:
+      - name: my-service
+        image: "alpine:latest"
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+          name: "http-node"
+        resources:
+            limits:
+              cpu: 50m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi

--- a/score/testdata/deployment-sets-no-revisionhistorylimit.yaml
+++ b/score/testdata/deployment-sets-no-revisionhistorylimit.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-service
+  template:
+    metadata:
+      annotations:
+        container.apparmor.security.beta.kubernetes.io: localhost/docker-default
+      labels:
+        app: my-service
+    spec:
+      containers:
+      - name: my-service
+        image: "alpine:latest"
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+          name: "http-node"
+        resources:
+            limits:
+              cpu: 50m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi

--- a/score/testdata/deployment-sets-revisionhistorylimit.yaml
+++ b/score/testdata/deployment-sets-revisionhistorylimit.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-service
+spec:
+  revisionHistoryLimit: 1
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-service
+  template:
+    metadata:
+      annotations:
+        container.apparmor.security.beta.kubernetes.io: localhost/docker-default
+      labels:
+        app: my-service
+    spec:
+      containers:
+      - name: my-service
+        image: "alpine:latest"
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+          name: "http-node"
+        resources:
+            limits:
+              cpu: 50m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi


### PR DESCRIPTION
```
RELNOTE: Adds a test for configuring a revisionHistoryLimit in a Deployment with thresholds:
- exists (score 1 if missing)
- high (score 7 if configured above value 5)
- ok (score 10 if configured less than or equal to 5)

```
[link](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy)
> You can set .spec.revisionHistoryLimit field in a Deployment to specify how many old ReplicaSets for this Deployment you want to retain. The rest will be garbage-collected in the background. By default, it is 10.