### PR TITLE
adding feature for apparmor annotation

### DIFF
--- a/score/apparmor/apparmor.go
+++ b/score/apparmor/apparmor.go
@@ -1,0 +1,31 @@
+package apparmor
+
+import (
+	"strings"
+
+	"github.com/zegl/kube-score/score/checks"
+	"github.com/zegl/kube-score/scorecard"
+        appsv1 "k8s.io/api/apps/v1"
+)
+
+func Register( allChecks *checks.Checks ) {
+        allChecks.RegisterDeploymentCheck( "Deployment sets apparmor annotation", `Makes sure that all Deployments set apparmor annotation`, deploymentHas() )
+}
+
+func deploymentHas() func( appsv1.Deployment ) ( scorecard.TestScore, error ) {
+        return func( deployment appsv1.Deployment ) ( score scorecard.TestScore, err error ) {
+		if armor, found := deployment.Spec.Template.GetObjectMeta().GetAnnotations()[ "container.apparmor.security.beta.kubernetes.io" ]; found {
+			if strings.Index( armor, "localhost/docker-default" ) != -1 {
+				score.Grade = scorecard.GradeAlmostOK
+				score.AddComment( "", "apparmor annotation is set:", "It is recommended to not use docker-default and instead customize a profile" )
+				return
+			}
+			score.Grade = scorecard.GradeAllOK
+			score.AddComment( "", "apparmor annotation is set:", armor )
+			return
+		}
+		score.Grade = scorecard.GradeCritical
+		score.AddComment( "", "apparmor annotation is not set", "It is recommended to set apparmor annotation and customize a profile" )
+		return
+	}
+}

--- a/score/apparmor_test.go
+++ b/score/apparmor_test.go
@@ -1,0 +1,13 @@
+package score
+
+import "testing"
+
+func TestApparmorAnnotation(t *testing.T) {
+	testExpectedScore(t, "deployment-sets-apparmor.yaml", "Deployment sets apparmor annotation", 10)
+}
+func TestNoApparmorAnnotation(t *testing.T) {
+        testExpectedScore(t, "deployment-sets-no-apparmor.yaml", "Deployment sets apparmor annotation", 1)
+}
+func TestDefaultApparmorAnnotation(t *testing.T) {
+        testExpectedScore(t, "deployment-sets-default-apparmor.yaml", "Deployment sets apparmor annotation", 7)
+}

--- a/score/score.go
+++ b/score/score.go
@@ -4,6 +4,7 @@ import (
 	"github.com/zegl/kube-score/config"
 	ks "github.com/zegl/kube-score/domain"
 	"github.com/zegl/kube-score/score/apps"
+	"github.com/zegl/kube-score/score/apparmor"
 	"github.com/zegl/kube-score/score/checks"
 	"github.com/zegl/kube-score/score/container"
 	"github.com/zegl/kube-score/score/cronjob"
@@ -33,6 +34,7 @@ func RegisterAllChecks(allObjects ks.AllTypes, cnf config.Configuration) *checks
 	service.Register(allChecks, allObjects, allObjects)
 	stable.Register(allChecks)
 	apps.Register(allChecks)
+	apparmor.Register(allChecks)
 	meta.Register(allChecks)
 
 	return allChecks

--- a/score/testdata/deployment-sets-apparmor.yaml
+++ b/score/testdata/deployment-sets-apparmor.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-service
+  template:
+    metadata:
+      annotations:
+        container.apparmor.security.beta.kubernetes.io: localhost/docker-custom
+      labels:
+        app: my-service
+    spec:
+      containers:
+      - name: my-service
+        image: "alpine:latest"
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+          name: "http-node"
+        resources:
+            limits:
+              cpu: 50m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi

--- a/score/testdata/deployment-sets-default-apparmor.yaml
+++ b/score/testdata/deployment-sets-default-apparmor.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-service
+  template:
+    metadata:
+      annotations:
+        container.apparmor.security.beta.kubernetes.io: localhost/docker-default
+      labels:
+        app: my-service
+    spec:
+      containers:
+      - name: my-service
+        image: "alpine:latest"
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+          name: "http-node"
+        resources:
+            limits:
+              cpu: 50m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi

--- a/score/testdata/deployment-sets-no-apparmor.yaml
+++ b/score/testdata/deployment-sets-no-apparmor.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-service
+  template:
+    metadata:
+      labels:
+        app: my-service
+    spec:
+      containers:
+      - name: my-service
+        image: "alpine:latest"
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+          name: "http-node"
+        resources:
+            limits:
+              cpu: 50m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi


### PR DESCRIPTION
```
RELNOTE: Adds a test for configuring an apparmor profile annotation in a Deployment with thresholds:
- exists (score 1 if missing)
- default (score 7 if configured as docker-default)
- ok (score 10 if configured and non-default)
```
[link](https://kubernetes.io/docs/tutorials/clusters/apparmor/)
> AppArmor is a Linux kernel security module that supplements the standard Linux user and group based permissions to confine programs to a limited set of resources. AppArmor can be configured for any application to reduce its potential attack surface and provide greater in-depth defense. It is configured through profiles tuned to whitelist the access needed by a specific program or container, such as Linux capabilities, network access, file permissions, etc. Each profile can be run in either enforcing mode, which blocks access to disallowed resources, or complain mode, which only reports violations.