### PR TITLE
all: verbose output flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,15 +72,14 @@ Actions:
 	help	Print this message
 
 Flags for score:
+      --enable-optional-test strings    Enable an optional test, can be set multiple times
       --exit-one-on-warning             Exit with code 1 in case of warnings
       --help                            Print help
       --ignore-container-cpu-limit      Disables the requirement of setting a container CPU limit
       --ignore-container-memory-limit   Disables the requirement of setting a container memory limit
       --ignore-test strings             Disable a test, can be set multiple times
-      --output-format string            Set to 'human' or 'ci'. If set to ci, kube-score will output the program in a format that is easier to parse by other programs. (default "human")
-      --threshold-ok int                The score threshold for treating an score as OK. Must be between 1 and 10 (inclusive). Scores graded below this threshold are WARNING or CRITICAL. (default 10)
-      --threshold-warning int           The score threshold for treating a score as WARNING. Grades below this threshold are CRITICAL. Must be between 1 and 10 (inclusive). (default 5)
-      --v                               Verbose output
+      --output-format string            Set to 'human', 'json' or 'ci'. If set to ci, kube-score will output the program in a format that is easier to parse by other programs. (default "human")
+  -v, --verbose count                   Enable verbose output, can be set multiple times for increased verbosity.
 ```
 
 ### Ignoring a test

--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,7 @@ import "io"
 
 type Configuration struct {
 	AllFiles                              []io.Reader
-	VerboseOutput                         bool
+	VerboseOutput                         int
 	IgnoreContainerCpuLimitRequirement    bool
 	IgnoreContainerMemoryLimitRequirement bool
 	IgnoredTests                          map[string]struct{}

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -258,7 +258,7 @@ func decodeItem(cnf config.Configuration, s *parsedObjects, detectedVersion sche
 		s.bothMetas = append(s.bothMetas, ks.BothMeta{ingress.TypeMeta, ingress.ObjectMeta})
 
 	default:
-		if cnf.VerboseOutput {
+		if cnf.VerboseOutput > 1 {
 			log.Printf("Unknown datatype: %s", detectedVersion.String())
 		}
 	}

--- a/score/apps/apps.go
+++ b/score/apps/apps.go
@@ -1,12 +1,13 @@
 package apps
 
 import (
-	"github.com/zegl/kube-score/score/checks"
-	"github.com/zegl/kube-score/score/internal"
-	"github.com/zegl/kube-score/scorecard"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/zegl/kube-score/score/checks"
+	"github.com/zegl/kube-score/score/internal"
+	"github.com/zegl/kube-score/scorecard"
 )
 
 func Register(allChecks *checks.Checks) {
@@ -19,8 +20,8 @@ func deploymentHasAntiAffinity(deployment appsv1.Deployment) (score scorecard.Te
 	// If replicas is not explicitly set, we'll still warn if the anti affinity is missing
 	// as that might indicate use of a Horizontal Pod Autoscaler
 	if deployment.Spec.Replicas != nil && *deployment.Spec.Replicas < 2 {
-		score.Grade = scorecard.GradeAllOK
-		score.AddComment("", "Skipped", "Skipped because the deployment has less than 2 replicas")
+		score.Skipped = true
+		score.AddComment("", "Skipped because the deployment has less than 2 replicas", "")
 		return
 	}
 
@@ -51,8 +52,8 @@ func statefulsetHasAntiAffinity(statefulset appsv1.StatefulSet) (score scorecard
 	// If replicas is not explicitly set, we'll still warn if the anti affinity is missing
 	// as that might indicate use of a Horizontal Pod Autoscaler
 	if statefulset.Spec.Replicas != nil && *statefulset.Spec.Replicas < 2 {
-		score.Grade = scorecard.GradeAllOK
-		score.AddComment("", "Skipped", "Skipped because the statefulset has less than 2 replicas")
+		score.Skipped = true
+		score.AddComment("", "Skipped because the statefulset has less than 2 replicas", "")
 		return
 	}
 

--- a/score/apps_test.go
+++ b/score/apps_test.go
@@ -25,7 +25,8 @@ func TestDeploymentHasPodAntiAffinityNotSet(t *testing.T) {
 }
 
 func TestDeploymentHasPodAntiAffinityOneReplica(t *testing.T) {
-	testExpectedScore(t, "deployment-host-antiaffinity-1-replica.yaml", "Deployment has host PodAntiAffinity", 10)
+	// skipped
+	testExpectedScore(t, "deployment-host-antiaffinity-1-replica.yaml", "Deployment has host PodAntiAffinity", 0)
 }
 
 func TestStatefulSetHasPodAntiAffinityPreffered(t *testing.T) {
@@ -41,7 +42,8 @@ func TestStatefulSetHasPodAntiAffinityNotSet(t *testing.T) {
 }
 
 func TestStatefulSetHasPodAntiAffinityOneReplica(t *testing.T) {
-	testExpectedScore(t, "statefulset-host-antiaffinity-1-replica.yaml", "StatefulSet has host PodAntiAffinity", 10)
+	// skipped
+	testExpectedScore(t, "statefulset-host-antiaffinity-1-replica.yaml", "StatefulSet has host PodAntiAffinity", 0)
 }
 
 func TestStatefulSetHasPodAntiAffinityUndefinedReplicas(t *testing.T) {

--- a/score/disruptionbudget/disruptionbudget.go
+++ b/score/disruptionbudget/disruptionbudget.go
@@ -40,8 +40,8 @@ func hasMatching(budgets []policyv1beta1.PodDisruptionBudget, namespace string, 
 func statefulSetHas(budgets []policyv1beta1.PodDisruptionBudget) func(appsv1.StatefulSet) (scorecard.TestScore, error) {
 	return func(statefulset appsv1.StatefulSet) (score scorecard.TestScore, err error) {
 		if statefulset.Spec.Replicas != nil && *statefulset.Spec.Replicas < 2 {
-			score.Grade = scorecard.GradeAllOK
-			score.AddComment("", "Skipped", "Skipped because the statefulset has less than 2 replicas")
+			score.Skipped = true
+			score.AddComment("", "Skipped because the statefulset has less than 2 replicas", "")
 			return
 		}
 
@@ -65,8 +65,8 @@ func statefulSetHas(budgets []policyv1beta1.PodDisruptionBudget) func(appsv1.Sta
 func deploymentHas(budgets []policyv1beta1.PodDisruptionBudget) func(appsv1.Deployment) (scorecard.TestScore, error) {
 	return func(deployment appsv1.Deployment) (score scorecard.TestScore, err error) {
 		if deployment.Spec.Replicas != nil && *deployment.Spec.Replicas < 2 {
-			score.Grade = scorecard.GradeAllOK
-			score.AddComment("", "Skipped", "Skipped because the deployment has less than 2 replicas")
+			score.Skipped = true
+			score.AddComment("", "Skipped because the deployment has less than 2 replicas", "")
 			return
 		}
 

--- a/score/disruptionbudget/disruptionbudget_test.go
+++ b/score/disruptionbudget/disruptionbudget_test.go
@@ -2,16 +2,20 @@ package disruptionbudget
 
 import (
 	"github.com/stretchr/testify/assert"
-	"github.com/zegl/kube-score/scorecard"
 	appsv1 "k8s.io/api/apps/v1"
 	"testing"
+
+	"github.com/zegl/kube-score/scorecard"
 )
 
 func TestStatefulSetReplicas(t *testing.T) {
-	cases := map[*int32]scorecard.Grade{
-		nil:        scorecard.GradeCritical, // failed
-		intptr(1):  scorecard.GradeAllOK,    // skipped
-		intptr(10): scorecard.GradeCritical, // failed
+	cases := map[*int32]struct {
+		grade   scorecard.Grade
+		skipped bool
+	}{
+		nil:        {scorecard.GradeCritical, false}, // failed
+		intptr(1):  {0, true},     // skipped
+		intptr(10): {scorecard.GradeCritical, false}, // failed
 	}
 
 	fn := statefulSetHas(nil)
@@ -20,19 +24,24 @@ func TestStatefulSetReplicas(t *testing.T) {
 		res, err := fn(appsv1.StatefulSet{Spec: appsv1.StatefulSetSpec{Replicas: replicas}})
 		assert.Nil(t, err)
 
+		assert.Equal(t, expected.skipped, res.Skipped)
+
 		if replicas == nil {
-			assert.Equal(t, expected, res.Grade, "replicas=nil")
+			assert.Equal(t, expected.grade, res.Grade, "replicas=nil")
 		} else {
-			assert.Equal(t, expected, res.Grade, "replicas=%+v", *replicas)
+			assert.Equal(t, expected.grade, res.Grade, "replicas=%+v", *replicas)
 		}
 	}
 }
 
 func TestDeploymentReplicas(t *testing.T) {
-	cases := map[*int32]scorecard.Grade{
-		nil:        scorecard.GradeCritical, // failed
-		intptr(1):  scorecard.GradeAllOK,    // skipped
-		intptr(10): scorecard.GradeCritical, // failed
+	cases := map[*int32]struct {
+		grade   scorecard.Grade
+		skipped bool
+	}{
+		nil:        {scorecard.GradeCritical, false}, // failed
+		intptr(1):  {0, true},     // skipped
+		intptr(10): {scorecard.GradeCritical, false}, // failed
 	}
 
 	fn := deploymentHas(nil)
@@ -41,10 +50,12 @@ func TestDeploymentReplicas(t *testing.T) {
 		res, err := fn(appsv1.Deployment{Spec: appsv1.DeploymentSpec{Replicas: replicas}})
 		assert.Nil(t, err)
 
+		assert.Equal(t, expected.skipped, res.Skipped)
+
 		if replicas == nil {
-			assert.Equal(t, expected, res.Grade, "replicas=nil")
+			assert.Equal(t, expected.grade, res.Grade, "replicas=nil")
 		} else {
-			assert.Equal(t, expected, res.Grade, "replicas=%+v", *replicas)
+			assert.Equal(t, expected.grade, res.Grade, "replicas=%+v", *replicas)
 		}
 	}
 }

--- a/score/score_test.go
+++ b/score/score_test.go
@@ -148,19 +148,24 @@ func TestConfigMapMultiDash(t *testing.T) {
 
 func TestAnnotationIgnore(t *testing.T) {
 	s, err := testScore(config.Configuration{
-		AllFiles: []io.Reader{testFile("ignore-annotation-service.yaml")},
+		VerboseOutput: 0,
+		AllFiles:      []io.Reader{testFile("ignore-annotation-service.yaml")},
 	})
 	assert.Nil(t, err)
 	assert.Len(t, s, 1)
 
+	tested := false
+
 	for _, o := range s {
 		for _, c := range o.Checks {
 			if c.Check.ID == "service-type" {
-				t.Error("service-type was tested")
+				assert.True(t, c.Skipped)
+				tested = true
 			}
 		}
 		assert.Equal(t, "node-port-service-with-ignore", o.ObjectMeta.Name)
 	}
+	assert.True(t, tested)
 }
 
 func TestList(t *testing.T) {

--- a/scorecard/scorecard.go
+++ b/scorecard/scorecard.go
@@ -1,6 +1,7 @@
 package scorecard
 
 import (
+	"fmt"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
 
@@ -79,18 +80,21 @@ func (so ScoredObject) HumanFriendlyRef() string {
 }
 
 func (so *ScoredObject) Add(ts TestScore, check ks.Check) {
-	// This test is ignored, don't save it
+	ts.Check = check
+
+	// This test is ignored (via annotations), don't save the score
 	if _, ok := so.ignoredChecks[check.ID]; ok {
-		return
+		ts.Skipped = true
+		ts.Comments = []TestScoreComment{{Summary: fmt.Sprintf("Skipped because %s is ignored", check.ID)}}
 	}
 
-	ts.Check = check
 	so.Checks = append(so.Checks, ts)
 }
 
 type TestScore struct {
 	Check    ks.Check
 	Grade    Grade
+	Skipped  bool
 	Comments []TestScoreComment
 }
 


### PR DESCRIPTION
By default, OK checks are hidden in the "human" output mode.

If the flag -v is set once, OK checks will be displayed.

If the flag -v is set twice, skipped checks will also be displayed.

This fixes #163

```
RELNOTE: hide OK and skipped checks by default in the "human" display mode. Set the -v flag once to display OK checks, set it twice to also display skipped checks.
```
