### PR TITLE
Emoji headers in human output

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For a full list of checks, see [README_CHECKS.md](README_CHECKS.md).
 
 ## Example output
 
-![](https://i.imgur.com/zETNJNS.png)
+![](https://user-images.githubusercontent.com/47952/63225706-5b90fe80-c1d3-11e9-8b9d-fad7e723afad.png)
 
 ## Usage in CI
 

--- a/cmd/kube-score/main.go
+++ b/cmd/kube-score/main.go
@@ -277,7 +277,7 @@ func outputHumanStep(card scorecard.TestScore, verboseOutput int) io.Reader {
 	}
 
 	for _, comment := range card.Comments {
-		fmt.Fprintf(w, "        * ")
+		fmt.Fprintf(w, "        · ")
 
 		if len(comment.Path) > 0 {
 			fmt.Fprintf(w, "%s -> ", comment.Path)

--- a/cmd/kube-score/main.go
+++ b/cmd/kube-score/main.go
@@ -216,11 +216,22 @@ func outputHuman(scoreCard *scorecard.Scorecard, verboseOutput int) io.Reader {
 		scoredObject := (*scoreCard)[key]
 
 		// Headers for each object
-		color.New(color.FgMagenta).Fprintf(w, "%s/%s %s", scoredObject.TypeMeta.APIVersion, scoredObject.TypeMeta.Kind, scoredObject.ObjectMeta.Name)
+		var writtenHeaderChars int
+		writtenHeaderChars, _ = color.New(color.FgMagenta).Fprintf(w, "%s/%s %s", scoredObject.TypeMeta.APIVersion, scoredObject.TypeMeta.Kind, scoredObject.ObjectMeta.Name)
 		if scoredObject.ObjectMeta.Namespace != "" {
-			color.New(color.FgMagenta).Fprintf(w, " in %s\n", scoredObject.ObjectMeta.Namespace)
+			written2, _ := color.New(color.FgMagenta).Fprintf(w, " in %s", scoredObject.ObjectMeta.Namespace)
+			writtenHeaderChars += written2
+		}
+
+		// Adjust to 80 columns wide
+		fmt.Fprintf(w, strings.Repeat(" ", 80-writtenHeaderChars-2))
+
+		if scoredObject.AnyBelowOrEqualToGrade(scorecard.GradeCritical) {
+			fmt.Fprintf(w, "💥\n")
+		} else if scoredObject.AnyBelowOrEqualToGrade(scorecard.GradeWarning) {
+			fmt.Fprintf(w, "🤔\n")
 		} else {
-			fmt.Fprintln(w)
+			fmt.Fprintf(w, "✅\n")
 		}
 
 		for _, card := range scoredObject.Checks {

--- a/cmd/kube-score/output_test.go
+++ b/cmd/kube-score/output_test.go
@@ -114,13 +114,13 @@ func TestHumanOutputDefault(t *testing.T) {
 	r := outputHuman(getTestCard(), 0)
 	all, err := ioutil.ReadAll(r)
 	assert.Nil(t, err)
-	assert.Equal(t, `v1/Testing foo in foofoo
+	assert.Equal(t, `v1/Testing foo in foofoo                                                      🤔
     [WARNING] test-warning-two-comments
         * a -> summary
             description
         * summary
             description
-v1/Testing bar-no-namespace
+v1/Testing bar-no-namespace                                                   🤔
     [WARNING] test-warning-two-comments
         * a -> summary
             description
@@ -133,7 +133,7 @@ func TestHumanOutputVerbose1(t *testing.T) {
 	r := outputHuman(getTestCard(), 1)
 	all, err := ioutil.ReadAll(r)
 	assert.Nil(t, err)
-	assert.Equal(t, `v1/Testing foo in foofoo
+	assert.Equal(t, `v1/Testing foo in foofoo                                                      🤔
     [WARNING] test-warning-two-comments
         * a -> summary
             description
@@ -142,7 +142,7 @@ func TestHumanOutputVerbose1(t *testing.T) {
     [OK] test-ok-comment
         * a -> summary
             description
-v1/Testing bar-no-namespace
+v1/Testing bar-no-namespace                                                   🤔
     [WARNING] test-warning-two-comments
         * a -> summary
             description
@@ -158,7 +158,7 @@ func TestHumanOutputVerbose2(t *testing.T) {
 	r := outputHuman(getTestCard(), 2)
 	all, err := ioutil.ReadAll(r)
 	assert.Nil(t, err)
-	assert.Equal(t, `v1/Testing foo in foofoo
+	assert.Equal(t, `v1/Testing foo in foofoo                                                      🤔
     [WARNING] test-warning-two-comments
         * a -> summary
             description
@@ -171,7 +171,7 @@ func TestHumanOutputVerbose2(t *testing.T) {
         * a -> skipped sum
             skipped description
     [SKIPPED] test-skipped-no-comment
-v1/Testing bar-no-namespace
+v1/Testing bar-no-namespace                                                   🤔
     [WARNING] test-warning-two-comments
         * a -> summary
             description
@@ -184,5 +184,96 @@ v1/Testing bar-no-namespace
         * a -> skipped sum
             skipped description
     [SKIPPED] test-skipped-no-comment
+`, string(all))
+}
+
+func getTestCardAllOK() *scorecard.Scorecard {
+	checks := []scorecard.TestScore{
+		{
+			Check: domain.Check{
+				Name: "test-warning-two-comments",
+			},
+			Grade: scorecard.GradeAllOK,
+			Comments: []scorecard.TestScoreComment{
+				{
+					Path:        "a",
+					Summary:     "summary",
+					Description: "description",
+				},
+				{
+					// No path
+					Summary:     "summary",
+					Description: "description",
+				},
+			},
+		},
+		{
+			Check: domain.Check{
+				Name: "test-ok-comment",
+			},
+			Grade: scorecard.GradeAllOK,
+			Comments: []scorecard.TestScoreComment{
+				{
+					Path:        "a",
+					Summary:     "summary",
+					Description: "description",
+				},
+			},
+		},
+		{
+			Check: domain.Check{
+				Name: "test-skipped-comment",
+			},
+			Skipped: true,
+			Comments: []scorecard.TestScoreComment{
+				{
+					Path:        "a",
+					Summary:     "skipped sum",
+					Description: "skipped description",
+				},
+			},
+		},
+		{
+			Check: domain.Check{
+				Name: "test-skipped-no-comment",
+			},
+			Skipped: true,
+		},
+	}
+
+	return &scorecard.Scorecard{
+		"a": &scorecard.ScoredObject{
+			TypeMeta: v1.TypeMeta{
+				Kind:       "Testing",
+				APIVersion: "v1",
+			},
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "foofoo",
+			},
+			Checks: checks,
+		},
+
+		// No namespace
+		"b": &scorecard.ScoredObject{
+			TypeMeta: v1.TypeMeta{
+				Kind:       "Testing",
+				APIVersion: "v1",
+			},
+			ObjectMeta: v1.ObjectMeta{
+				Name: "bar-no-namespace",
+			},
+			Checks: checks,
+		},
+	}
+}
+
+func TestHumanOutputAllOKDefault(t *testing.T) {
+	// color.NoColor = false
+	r := outputHuman(getTestCardAllOK(), 0)
+	all, err := ioutil.ReadAll(r)
+	assert.Nil(t, err)
+	assert.Equal(t, `v1/Testing foo in foofoo                                                      ✅
+v1/Testing bar-no-namespace                                                   ✅
 `, string(all))
 }

--- a/cmd/kube-score/output_test.go
+++ b/cmd/kube-score/output_test.go
@@ -111,77 +111,77 @@ func TestCiOutput(t *testing.T) {
 }
 
 func TestHumanOutputDefault(t *testing.T) {
-	r := outputHuman(getTestCard(), 0)
+	r := outputHuman(getTestCard(), 0, 100)
 	all, err := ioutil.ReadAll(r)
 	assert.Nil(t, err)
 	assert.Equal(t, `v1/Testing foo in foofoo                                                      🤔
     [WARNING] test-warning-two-comments
-        * a -> summary
+        · a -> summary
             description
-        * summary
+        · summary
             description
 v1/Testing bar-no-namespace                                                   🤔
     [WARNING] test-warning-two-comments
-        * a -> summary
+        · a -> summary
             description
-        * summary
+        · summary
             description
 `, string(all))
 }
 
 func TestHumanOutputVerbose1(t *testing.T) {
-	r := outputHuman(getTestCard(), 1)
+	r := outputHuman(getTestCard(), 1, 100)
 	all, err := ioutil.ReadAll(r)
 	assert.Nil(t, err)
 	assert.Equal(t, `v1/Testing foo in foofoo                                                      🤔
     [WARNING] test-warning-two-comments
-        * a -> summary
+        · a -> summary
             description
-        * summary
+        · summary
             description
     [OK] test-ok-comment
-        * a -> summary
+        · a -> summary
             description
 v1/Testing bar-no-namespace                                                   🤔
     [WARNING] test-warning-two-comments
-        * a -> summary
+        · a -> summary
             description
-        * summary
+        · summary
             description
     [OK] test-ok-comment
-        * a -> summary
+        · a -> summary
             description
 `, string(all))
 }
 
 func TestHumanOutputVerbose2(t *testing.T) {
-	r := outputHuman(getTestCard(), 2)
+	r := outputHuman(getTestCard(), 2, 100)
 	all, err := ioutil.ReadAll(r)
 	assert.Nil(t, err)
 	assert.Equal(t, `v1/Testing foo in foofoo                                                      🤔
     [WARNING] test-warning-two-comments
-        * a -> summary
+        · a -> summary
             description
-        * summary
+        · summary
             description
     [OK] test-ok-comment
-        * a -> summary
+        · a -> summary
             description
     [SKIPPED] test-skipped-comment
-        * a -> skipped sum
+        · a -> skipped sum
             skipped description
     [SKIPPED] test-skipped-no-comment
 v1/Testing bar-no-namespace                                                   🤔
     [WARNING] test-warning-two-comments
-        * a -> summary
+        · a -> summary
             description
-        * summary
+        · summary
             description
     [OK] test-ok-comment
-        * a -> summary
+        · a -> summary
             description
     [SKIPPED] test-skipped-comment
-        * a -> skipped sum
+        · a -> skipped sum
             skipped description
     [SKIPPED] test-skipped-no-comment
 `, string(all))
@@ -269,11 +269,89 @@ func getTestCardAllOK() *scorecard.Scorecard {
 }
 
 func TestHumanOutputAllOKDefault(t *testing.T) {
-	// color.NoColor = false
-	r := outputHuman(getTestCardAllOK(), 0)
+	r := outputHuman(getTestCardAllOK(), 0, 100)
 	all, err := ioutil.ReadAll(r)
 	assert.Nil(t, err)
 	assert.Equal(t, `v1/Testing foo in foofoo                                                      ✅
 v1/Testing bar-no-namespace                                                   ✅
 `, string(all))
 }
+
+func getTestCardLongDescription() *scorecard.Scorecard {
+	checks := []scorecard.TestScore{
+		{
+			Check: domain.Check{
+				Name: "test-warning-two-comments",
+			},
+			Grade: scorecard.GradeWarning,
+			Comments: []scorecard.TestScoreComment{
+				{
+					Path:        "a",
+					Summary:     "summary",
+					Description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras elementum sagittis lacus, a dictum tortor lobortis vel. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Nulla eu neque erat. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Maecenas et nisl venenatis, elementum augue a, porttitor libero.",
+				},
+			},
+		},
+	}
+
+	return &scorecard.Scorecard{
+		"a": &scorecard.ScoredObject{
+			TypeMeta: v1.TypeMeta{
+				Kind:       "Testing",
+				APIVersion: "v1",
+			},
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "foofoo",
+			},
+			Checks: checks,
+		},
+	}
+}
+
+func TestHumanOutputLogDescription120Width(t *testing.T) {
+	r := outputHuman(getTestCardLongDescription(), 0, 120)
+	all, err := ioutil.ReadAll(r)
+	assert.Nil(t, err)
+	assert.Equal(t, `v1/Testing foo in foofoo                                                      🤔
+    [WARNING] test-warning-two-comments
+        · a -> summary
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras elementum sagittis lacus, a dictum tortor
+            lobortis vel. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+            Nulla eu neque erat. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae;
+            Maecenas et nisl venenatis, elementum augue a, porttitor libero.
+`, string(all))
+}
+
+func TestHumanOutputLogDescription100Width(t *testing.T) {
+	r := outputHuman(getTestCardLongDescription(), 0, 100)
+	all, err := ioutil.ReadAll(r)
+	assert.Nil(t, err)
+	assert.Equal(t, `v1/Testing foo in foofoo                                                      🤔
+    [WARNING] test-warning-two-comments
+        · a -> summary
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras elementum sagittis lacus,
+            a dictum tortor lobortis vel. Pellentesque habitant morbi tristique senectus et netus et
+            malesuada fames ac turpis egestas. Nulla eu neque erat. Vestibulum ante ipsum primis in
+            faucibus orci luctus et ultrices posuere cubilia Curae; Maecenas et nisl venenatis,
+            elementum augue a, porttitor libero.
+`, string(all))
+}
+
+func TestHumanOutputLogDescription80Width(t *testing.T) {
+	r := outputHuman(getTestCardLongDescription(), 0, 80)
+	all, err := ioutil.ReadAll(r)
+	assert.Nil(t, err)
+	assert.Equal(t, `v1/Testing foo in foofoo                                                      🤔
+    [WARNING] test-warning-two-comments
+        · a -> summary
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras
+            elementum sagittis lacus, a dictum tortor lobortis vel. Pellentesque
+            habitant morbi tristique senectus et netus et malesuada fames ac
+            turpis egestas. Nulla eu neque erat. Vestibulum ante ipsum primis in
+            faucibus orci luctus et ultrices posuere cubilia Curae; Maecenas et
+            nisl venenatis, elementum augue a, porttitor libero.
+`, string(all))
+}
+
+

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/zegl/kube-score
 require (
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c // indirect
+	github.com/eidolon/wordwrap v0.0.0-20161011182207-e0f54129b8bb
 	github.com/elazarl/goproxy v0.0.0-20190711103511-473e67f1d7d2 // indirect
 	github.com/emicklei/go-restful v2.9.6+incompatible // indirect
 	github.com/evanphx/json-patch v4.5.0+incompatible // indirect
@@ -22,7 +23,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20190414153302-2ae31c8b6b30 // indirect
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.4.0
-	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 // indirect
+	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 // indirect
 	golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e // indirect
 	golang.org/x/tools v0.0.0-20190728063539-fc6e2057e7f6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
+github.com/eidolon/wordwrap v0.0.0-20161011182207-e0f54129b8bb h1:ioQwBmKdOCpMVS/bDaESqNWXIE/aw4+gsVtysCGMWZ4=
+github.com/eidolon/wordwrap v0.0.0-20161011182207-e0f54129b8bb/go.mod h1:ZAPs+OyRzeVJFGvXVDVffgCzQfjg3qU9Ig8G/MU3zZ4=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20190410145444-c548f45dcf1d/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20190421051319-9d40249d3c2f/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
@@ -131,6 +133,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190411191339-88737f569e3a/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190621222207-cc06ce4a13d4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -161,6 +164,7 @@ golang.org/x/sys v0.0.0-20190415145633-3fd5a3612ccd h1:MNN7PRW7zYXd8upVO5qfKeOnQ
 golang.org/x/sys v0.0.0-20190415145633-3fd5a3612ccd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190621203818-d432491b9138/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e h1:D5TXcfTk7xF7hvieo4QErS3qqCB4teTffacDWr7CI+0=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=

--- a/score/networkpolicy/networkpolicy.go
+++ b/score/networkpolicy/networkpolicy.go
@@ -1,13 +1,14 @@
 package networkpolicy
 
 import (
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	ks "github.com/zegl/kube-score/domain"
 	"github.com/zegl/kube-score/score/checks"
 	"github.com/zegl/kube-score/score/internal"
 	"github.com/zegl/kube-score/scorecard"
-	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Register(allChecks *checks.Checks, netpols ks.NetworkPolicies, pods ks.Pods, podspecers ks.PodSpeccers) {

--- a/score/testdata/all-ok.yaml
+++ b/score/testdata/all-ok.yaml
@@ -2,8 +2,45 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod-test-1
+  namespace: testspace
+  labels:
+    app: foo-all-ok
 spec:
   containers:
     - name: foobar
       image: foo/bar:123
       imagePullPolicy: Always
+      resources:
+        requests:
+          cpu: 1
+          memory: 1
+        limits:
+          cpu: 1
+          memory: 1
+      readinessProbe:
+        httpGet:
+          path: /ready
+          port: 8080
+      livenessProbe:
+        httpGet:
+          path: /live
+          port: 8080
+      securityContext:
+        privileged: False
+        runAsUser: 30000
+        runAsGroup: 30000
+        readOnlyRootFilesystem: True
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: foo-all-ok-netpol
+  namespace: testspace
+spec:
+  podSelector:
+    matchLabels:
+      app: foo-all-ok
+  policyTypes:
+    - Egress
+    - Ingress

--- a/scorecard/scorecard.go
+++ b/scorecard/scorecard.go
@@ -39,10 +39,8 @@ func (s Scorecard) NewObject(typeMeta metav1.TypeMeta, objectMeta metav1.ObjectM
 
 func (s Scorecard) AnyBelowOrEqualToGrade(threshold Grade) bool {
 	for _, o := range s {
-		for _, s := range o.Checks {
-			if s.Grade <= threshold {
-				return true
-			}
+		if o.AnyBelowOrEqualToGrade(threshold) {
+			return true
 		}
 	}
 	return false
@@ -54,6 +52,15 @@ type ScoredObject struct {
 	Checks     []TestScore
 
 	ignoredChecks map[string]struct{}
+}
+
+func (s ScoredObject) AnyBelowOrEqualToGrade(threshold Grade) bool {
+	for _, o := range s.Checks {
+		if o.Skipped == false && o.Grade <= threshold {
+			return true
+		}
+	}
+	return false
 }
 
 func (so *ScoredObject) setIgnoredTests() {


### PR DESCRIPTION
Use emojis to display the status of each object:

<img width="1002" alt="Screen Shot 2019-08-18 at 15 35 13 " src="https://user-images.githubusercontent.com/47952/63225163-d8b97500-c1cd-11e9-86c9-2b48ec095794.png">

New README image:

<img width="786" alt="Screen Shot 2019-08-18 at 16 14 45 " src="https://user-images.githubusercontent.com/47952/63225706-5b90fe80-c1d3-11e9-8b9d-fad7e723afad.png">


```
RELNOTE: Display emojis after the name of each object to indicate the status. This is only affects the human output mode.
```
