### PR TITLE
Prevent panic with negative string sizes

### DIFF
--- a/cmd/kube-score/main.go
+++ b/cmd/kube-score/main.go
@@ -216,6 +216,13 @@ func safeRepeat(s string, count int) string {
 	return strings.Repeat(s, count)
 }
 
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
 func outputHuman(scoreCard *scorecard.Scorecard, verboseOutput int, termWidth int) io.Reader {
 	// Print the items sorted by scorecard key
 	var keys []string
@@ -237,8 +244,8 @@ func outputHuman(scoreCard *scorecard.Scorecard, verboseOutput int, termWidth in
 			writtenHeaderChars += written2
 		}
 
-		// Adjust to 80 columns wide
-		fmt.Fprintf(w, safeRepeat(" ", 80-writtenHeaderChars-2))
+		// Adjust to termsize
+		fmt.Fprintf(w, safeRepeat(" ", min(80, termWidth)-writtenHeaderChars-2))
 
 		if scoredObject.AnyBelowOrEqualToGrade(scorecard.GradeCritical) {
 			fmt.Fprintf(w, "💥\n")
@@ -300,7 +307,11 @@ func outputHumanStep(card scorecard.TestScore, verboseOutput int, termWidth int)
 		fmt.Fprint(w, comment.Summary)
 
 		if len(comment.Description) > 0 {
-			wrapper := wordwrap.Wrapper(termWidth-12, false)
+			wrapWidth := termWidth - 12
+			if wrapWidth < 40 {
+				wrapWidth = 40
+			}
+			wrapper := wordwrap.Wrapper(wrapWidth, false)
 			wrapped := wrapper(comment.Description)
 			fmt.Fprintln(w)
 			fmt.Fprintf(w, wordwrap.Indent(wrapped, strings.Repeat(" ", 12), false))

--- a/cmd/kube-score/output_test.go
+++ b/cmd/kube-score/output_test.go
@@ -353,3 +353,51 @@ func TestHumanOutputLogDescription80Width(t *testing.T) {
             nisl venenatis, elementum augue a, porttitor libero.
 `, string(all))
 }
+
+func getTestCardLongTitle() *scorecard.Scorecard {
+	checks := []scorecard.TestScore{
+		{
+			Check: domain.Check{
+				Name: "test-warning-two-comments",
+			},
+			Grade: scorecard.GradeWarning,
+			Comments: []scorecard.TestScoreComment{
+				{
+					Path:        "a",
+					Summary:     "summary",
+					Description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras elementum sagittis lacus, a dictum tortor lobortis vel. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Nulla eu neque erat. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Maecenas et nisl venenatis, elementum augue a, porttitor libero.",
+				},
+			},
+		},
+	}
+
+	return &scorecard.Scorecard{
+		"a": &scorecard.ScoredObject{
+			TypeMeta: v1.TypeMeta{
+				Kind:       "Testing",
+				APIVersion: "v1",
+			},
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "this-is-a-very-long-title-this-is-a-very-long-title-this-is-a-very-long-title-this-is-a-very-long-title-this-is-a-very-long-title",
+				Namespace: "foofoo",
+			},
+			Checks: checks,
+		},
+	}
+}
+
+func TestHumanOutputWithLongObjectNames(t *testing.T) {
+	r := outputHuman(getTestCardLongTitle(), 0, 80)
+	all, err := ioutil.ReadAll(r)
+	assert.Nil(t, err)
+	assert.Equal(t, `v1/Testing this-is-a-very-long-title-this-is-a-very-long-title-this-is-a-very-long-title-this-is-a-very-long-title-this-is-a-very-long-title in foofoo🤔
+    [WARNING] test-warning-two-comments
+        · a -> summary
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras
+            elementum sagittis lacus, a dictum tortor lobortis vel. Pellentesque
+            habitant morbi tristique senectus et netus et malesuada fames ac
+            turpis egestas. Nulla eu neque erat. Vestibulum ante ipsum primis in
+            faucibus orci luctus et ultrices posuere cubilia Curae; Maecenas et
+            nisl venenatis, elementum augue a, porttitor libero.
+`, string(all))
+}

--- a/cmd/kube-score/output_test.go
+++ b/cmd/kube-score/output_test.go
@@ -354,6 +354,26 @@ func TestHumanOutputLogDescription80Width(t *testing.T) {
 `, string(all))
 }
 
+func TestHumanOutputLogDescription0Width(t *testing.T) {
+	r := outputHuman(getTestCardLongDescription(), 0, 0)
+	all, err := ioutil.ReadAll(r)
+	assert.Nil(t, err)
+	assert.Equal(t, `v1/Testing foo in foofoo🤔
+    [WARNING] test-warning-two-comments
+        · a -> summary
+            Lorem ipsum dolor sit amet, consectetur
+            adipiscing elit. Cras elementum sagittis
+            lacus, a dictum tortor lobortis vel.
+            Pellentesque habitant morbi tristique
+            senectus et netus et malesuada fames ac
+            turpis egestas. Nulla eu neque erat.
+            Vestibulum ante ipsum primis in faucibus
+            orci luctus et ultrices posuere cubilia
+            Curae; Maecenas et nisl venenatis,
+            elementum augue a, porttitor libero.
+`, string(all))
+}
+
 func getTestCardLongTitle() *scorecard.Scorecard {
 	checks := []scorecard.TestScore{
 		{


### PR DESCRIPTION
Fixes #176 
Fixes #175

```
RELNOTE: Fixes for panics in the human output mode when the term size can not be detected, or was too small
```