### PR TITLE
cmd: allow disabling kube-score/ignore annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,15 @@ Actions:
 	help	Print this message
 
 Flags for score:
-      --enable-optional-test strings    Enable an optional test, can be set multiple times
-      --exit-one-on-warning             Exit with code 1 in case of warnings
-      --help                            Print help
-      --ignore-container-cpu-limit      Disables the requirement of setting a container CPU limit
-      --ignore-container-memory-limit   Disables the requirement of setting a container memory limit
-      --ignore-test strings             Disable a test, can be set multiple times
-      --output-format string            Set to 'human', 'json' or 'ci'. If set to ci, kube-score will output the program in a format that is easier to parse by other programs. (default "human")
-  -v, --verbose count                   Enable verbose output, can be set multiple times for increased verbosity.
+      --disable-ignore-checks-annotations   Set to true to disable the effect of the 'kube-score/ignore' annotations
+      --enable-optional-test strings        Enable an optional test, can be set multiple times
+      --exit-one-on-warning                 Exit with code 1 in case of warnings
+      --help                                Print help
+      --ignore-container-cpu-limit          Disables the requirement of setting a container CPU limit
+      --ignore-container-memory-limit       Disables the requirement of setting a container memory limit
+      --ignore-test strings                 Disable a test, can be set multiple times
+  -o, --output-format string                Set to 'human', 'json' or 'ci'. If set to ci, kube-score will output the program in a format that is easier to parse by other programs. (default "human")
+  -v, --verbose count                       Enable verbose output, can be set multiple times for increased verbosity.
 ```
 
 ### Ignoring a test

--- a/cmd/kube-score/main.go
+++ b/cmd/kube-score/main.go
@@ -85,6 +85,7 @@ func scoreFiles() error {
 	outputFormat := fs.StringP("output-format", "o", "human", "Set to 'human', 'json' or 'ci'. If set to ci, kube-score will output the program in a format that is easier to parse by other programs.")
 	optionalTests := fs.StringSlice("enable-optional-test", []string{}, "Enable an optional test, can be set multiple times")
 	ignoreTests := fs.StringSlice("ignore-test", []string{}, "Disable a test, can be set multiple times")
+	disableIgnoreChecksAnnotation := fs.Bool("disable-ignore-checks-annotations", false, "Set to true to disable the effect of the 'kube-score/ignore' annotations")
 	setDefault(fs, "score", false)
 
 	err := fs.Parse(os.Args[2:])
@@ -139,6 +140,7 @@ Use "-" as filename to read from STDIN.`)
 		IgnoreContainerMemoryLimitRequirement: *ignoreContainerMemoryLimit,
 		IgnoredTests:                          ignoredTests,
 		EnabledOptionalTests:                  enabledOptionalTests,
+		UseIgnoreChecksAnnotation:             !*disableIgnoreChecksAnnotation,
 	}
 
 	parsedFiles, err := parser.ParseFiles(cnf)

--- a/config/config.go
+++ b/config/config.go
@@ -9,4 +9,5 @@ type Configuration struct {
 	IgnoreContainerMemoryLimitRequirement bool
 	IgnoredTests                          map[string]struct{}
 	EnabledOptionalTests                  map[string]struct{}
+	UseIgnoreChecksAnnotation             bool
 }

--- a/score/score_test.go
+++ b/score/score_test.go
@@ -165,8 +165,9 @@ func TestConfigMapMultiDash(t *testing.T) {
 func TestAnnotationIgnore(t *testing.T) {
 	t.Parallel()
 	s, err := testScore(config.Configuration{
-		VerboseOutput: 0,
-		AllFiles:      []io.Reader{testFile("ignore-annotation-service.yaml")},
+		VerboseOutput:             0,
+		AllFiles:                  []io.Reader{testFile("ignore-annotation-service.yaml")},
+		UseIgnoreChecksAnnotation: true,
 	})
 	assert.Nil(t, err)
 	assert.Len(t, s, 1)
@@ -177,6 +178,31 @@ func TestAnnotationIgnore(t *testing.T) {
 		for _, c := range o.Checks {
 			if c.Check.ID == "service-type" {
 				assert.True(t, c.Skipped)
+				tested = true
+			}
+		}
+		assert.Equal(t, "node-port-service-with-ignore", o.ObjectMeta.Name)
+	}
+	assert.True(t, tested)
+}
+
+func TestAnnotationIgnoreDisabled(t *testing.T) {
+	t.Parallel()
+	s, err := testScore(config.Configuration{
+		VerboseOutput:             0,
+		AllFiles:                  []io.Reader{testFile("ignore-annotation-service.yaml")},
+		UseIgnoreChecksAnnotation: false,
+	})
+	assert.Nil(t, err)
+	assert.Len(t, s, 1)
+
+	tested := false
+
+	for _, o := range s {
+		for _, c := range o.Checks {
+			if c.Check.ID == "service-type" {
+				assert.False(t, c.Skipped)
+				assert.Equal(t, scorecard.GradeWarning, c.Grade)
 				tested = true
 			}
 		}

--- a/scorecard/scorecard.go
+++ b/scorecard/scorecard.go
@@ -19,7 +19,7 @@ func New() Scorecard {
 	return make(Scorecard)
 }
 
-func (s Scorecard) NewObject(typeMeta metav1.TypeMeta, objectMeta metav1.ObjectMeta) *ScoredObject {
+func (s Scorecard) NewObject(typeMeta metav1.TypeMeta, objectMeta metav1.ObjectMeta, useIgnoreChecksAnnotation bool) *ScoredObject {
 	o := &ScoredObject{
 		TypeMeta:   typeMeta,
 		ObjectMeta: objectMeta,
@@ -31,7 +31,9 @@ func (s Scorecard) NewObject(typeMeta metav1.TypeMeta, objectMeta metav1.ObjectM
 		return object
 	}
 
-	o.setIgnoredTests()
+	if useIgnoreChecksAnnotation {
+		o.setIgnoredTests()
+	}
 
 	s[o.resourceRefKey()] = o
 	return o


### PR DESCRIPTION
Via new --disable-ignore-checks-annotations flag

Fixes #202 

```
RELNOTE: Allow disabling `kube-score/ignore` annotation with a new `--disable-ignore-checks-annotations` flag
```
