### PR TITLE
JSON output v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Flags for score:
       --ignore-container-memory-limit       Disables the requirement of setting a container memory limit
       --ignore-test strings                 Disable a test, can be set multiple times
   -o, --output-format string                Set to 'human', 'json' or 'ci'. If set to ci, kube-score will output the program in a format that is easier to parse by other programs. (default "human")
+      --output-version string               Set to 'v2' or 'v1'. Affects the output of the 'json' output format. 'v2' will become the default in a future release. (default "v1")
   -v, --verbose count                       Enable verbose output, can be set multiple times for increased verbosity.
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Flags for score:
       --ignore-container-memory-limit       Disables the requirement of setting a container memory limit
       --ignore-test strings                 Disable a test, can be set multiple times
   -o, --output-format string                Set to 'human', 'json' or 'ci'. If set to ci, kube-score will output the program in a format that is easier to parse by other programs. (default "human")
-      --output-version string               Set to 'v2' or 'v1'. Affects the output of the 'json' output format. 'v2' will become the default in a future release. (default "v1")
+      --output-version string               Changes the version of the --output-format. The 'json' format has version 'v1' (default) and 'v2'. The 'human' and 'ci' formats has only version 'v1' (default). If not explicitly set, the default version for that particular output format will be used.
   -v, --verbose count                       Enable verbose output, can be set multiple times for increased verbosity.
 ```
 

--- a/cmd/kube-score/main.go
+++ b/cmd/kube-score/main.go
@@ -84,7 +84,7 @@ func scoreFiles() error {
 	verboseOutput := fs.CountP("verbose", "v", "Enable verbose output, can be set multiple times for increased verbosity.")
 	printHelp := fs.Bool("help", false, "Print help")
 	outputFormat := fs.StringP("output-format", "o", "human", "Set to 'human', 'json' or 'ci'. If set to ci, kube-score will output the program in a format that is easier to parse by other programs.")
-	outputVersion := fs.String("output-version", "v1", "Set to 'v2' or 'v1'. Affects the output of the 'json' output format. 'v2' will become the default in a future release.")
+	outputVersion := fs.String("output-version", "", "Changes the version of the --output-format. The 'json' format has version 'v1' (default) and 'v2'. The 'human' and 'ci' formats has only version 'v1' (default). If not explicitly set, the default version for that particular output format will be used.")
 	optionalTests := fs.StringSlice("enable-optional-test", []string{}, "Enable an optional test, can be set multiple times")
 	ignoreTests := fs.StringSlice("ignore-test", []string{}, "Disable a test, can be set multiple times")
 	disableIgnoreChecksAnnotation := fs.Bool("disable-ignore-checks-annotations", false, "Set to true to disable the effect of the 'kube-score/ignore' annotations")
@@ -166,21 +166,23 @@ Use "-" as filename to read from STDIN.`)
 
 	var r io.Reader
 
-	if *outputFormat == "json" && *outputVersion == "v1" {
+	version := getOutputVersion(*outputVersion, *outputFormat)
+
+	if *outputFormat == "json" && version == "v1" {
 		d, _ := json.MarshalIndent(scoreCard, "", "    ")
 		w := bytes.NewBufferString("")
 		w.WriteString(string(d))
 		r = w
-	} else if *outputFormat == "json" && *outputVersion == "v2" {
+	} else if *outputFormat == "json" && version == "v2" {
 		r = json_v2.Output(scoreCard)
-	} else if *outputFormat == "human" && *outputVersion == "v1" {
+	} else if *outputFormat == "human" && version == "v1" {
 		termWidth, _, err := terminal.GetSize(int(os.Stdin.Fd()))
 		// Assume a width of 80 if it can't be detected
 		if err != nil {
 			termWidth = 80
 		}
 		r = human.Human(scoreCard, *verboseOutput, termWidth)
-	} else if *outputFormat == "ci" && *outputVersion == "v1" {
+	} else if *outputFormat == "ci" && version == "v1" {
 		r = ci.CI(scoreCard)
 	} else {
 		return fmt.Errorf("error: Unknown --output-format or --output-version")
@@ -190,6 +192,19 @@ Use "-" as filename to read from STDIN.`)
 	fmt.Print(string(output))
 	os.Exit(exitCode)
 	return nil
+}
+
+func getOutputVersion(flagValue, format string) string {
+	if len(flagValue) > 0 {
+		return flagValue
+	}
+
+	switch format {
+	case "json":
+		return "v1" // TODO: Switch this to v2 in v1.6.0
+	default:
+		return "v1"
+	}
 }
 
 func listChecks() {

--- a/cmd/kube-score/main.go
+++ b/cmd/kube-score/main.go
@@ -173,15 +173,17 @@ Use "-" as filename to read from STDIN.`)
 		r = w
 	} else if *outputFormat == "json" && *outputVersion == "v2" {
 		r = json_v2.Output(scoreCard)
-	} else if *outputFormat == "human" {
+	} else if *outputFormat == "human" && *outputVersion == "v1" {
 		termWidth, _, err := terminal.GetSize(int(os.Stdin.Fd()))
 		// Assume a width of 80 if it can't be detected
 		if err != nil {
 			termWidth = 80
 		}
 		r = human.Human(scoreCard, *verboseOutput, termWidth)
-	} else {
+	} else if *outputFormat == "ci" && *outputVersion == "v1" {
 		r = ci.CI(scoreCard)
+	} else {
+		return fmt.Errorf("error: Unknown --output-format or --output-version")
 	}
 
 	output, _ := ioutil.ReadAll(r)

--- a/renderer/json_v2/api.go
+++ b/renderer/json_v2/api.go
@@ -1,0 +1,91 @@
+package json_v2
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ks "github.com/zegl/kube-score/domain"
+	"github.com/zegl/kube-score/scorecard"
+)
+
+type Check struct {
+	Name       string `json:"name"`
+	ID         string `json:"id"`
+	TargetType string `json:"target_type"`
+	Comment    string `json:"comment"`
+	Optional   bool   `json:"optional"`
+}
+
+type ScoredObject struct {
+	ObjectName string            `json:"object_name"`
+	TypeMeta   metav1.TypeMeta   `json:"type_meta"`
+	ObjectMeta metav1.ObjectMeta `json:"object_meta"`
+	Checks     []TestScore       `json:"checks"`
+}
+
+type TestScore struct {
+	Check    Check              `json:"check"`
+	Grade    scorecard.Grade    `json:"grade"`
+	Skipped  bool               `json:"skipped"`
+	Comments []TestScoreComment `json:"comments"`
+}
+
+type TestScoreComment struct {
+	Path        string `json:"path"`
+	Summary     string `json:"summary"`
+	Description string `json:"description"`
+}
+
+func Output(input *scorecard.Scorecard) io.Reader {
+	var objs []ScoredObject
+
+	for k, v := range *input {
+		objs = append(objs, ScoredObject{
+			ObjectName: k,
+			TypeMeta:   v.TypeMeta,
+			ObjectMeta: v.ObjectMeta,
+			Checks:     convertTestScore(v.Checks),
+		})
+	}
+
+	j, err := json.MarshalIndent(objs, "", "    ")
+	if err != nil {
+		panic(err)
+	}
+	return bytes.NewBuffer(j)
+}
+
+func convertTestScore(in []scorecard.TestScore) (res []TestScore) {
+	for _, v := range in {
+		res = append(res, TestScore{
+			Check:    convertCheck(v.Check),
+			Grade:    v.Grade,
+			Skipped:  v.Skipped,
+			Comments: convertComments(v.Comments),
+		})
+	}
+	return
+}
+
+func convertComments(in []scorecard.TestScoreComment) (res []TestScoreComment) {
+	for _, v := range in {
+		res = append(res, TestScoreComment{
+			Path:        v.Path,
+			Summary:     v.Summary,
+			Description: v.Description,
+		})
+	}
+	return
+}
+
+func convertCheck(v ks.Check) Check {
+	return Check{
+		Name:       v.Name,
+		ID:         v.ID,
+		TargetType: v.TargetType,
+		Comment:    v.Comment,
+		Optional:   v.Optional,
+	}
+}


### PR DESCRIPTION
Implements a v2 JSON API behind a new `--output-version` flag. 

JSON names are now snake_case, and the top object is a list instead of a map.

As of v1.5.0  `--output-version=v1` (the default) will be deprecated. In `v1.6.0` the default will be switched to `v2`. The v1 output version will be removed in `v1.7.0`.

Fixes #186.

```
RELNOTE: Version 2 of the JSON API is now available behind the `--output-version=v2` flag. The current default (`v1`) is now deprecated, and will be removed in a future release. See the PR for more information.
```
