### PR TITLE
Add support for '--ignore-container-cpu-limit' to 'container-resource…

### DIFF
--- a/score/container/container.go
+++ b/score/container/container.go
@@ -12,7 +12,7 @@ import (
 
 func Register(allChecks *checks.Checks, cnf config.Configuration) {
 	allChecks.RegisterPodCheck("Container Resources", `Makes sure that all pods have resource limits and requests set. The --ignore-container-cpu-limit flag can be used to disable the requirement of having a CPU limit`, containerResources(!cnf.IgnoreContainerCpuLimitRequirement, !cnf.IgnoreContainerMemoryLimitRequirement))
-	allChecks.RegisterOptionalPodCheck("Container Resource Requests Equal Limits", `Makes sure that all pods have the same requests as limits on resources set.`, containerResourceRequestsEqualLimits)
+	allChecks.RegisterOptionalPodCheck("Container Resource Requests Equal Limits", `Makes sure that all pods have the same requests as limits on resources set.`, containerResourceRequestsEqualLimits(!cnf.IgnoreContainerCpuLimitRequirement))
 	allChecks.RegisterPodCheck("Container Image Tag", `Makes sure that a explicit non-latest tag is used`, containerImageTag)
 	allChecks.RegisterPodCheck("Container Image Pull Policy", `Makes sure that the pullPolicy is set to Always. This makes sure that imagePullSecrets are always validated.`, containerImagePullPolicy)
 }
@@ -64,34 +64,36 @@ func containerResources(requireCPULimit bool, requireMemoryLimit bool) func(core
 }
 
 // containerResourceRequestsEqualLimits checks that all containers have equal requests and limits for CPU and memory resources
-func containerResourceRequestsEqualLimits(podTemplate corev1.PodTemplateSpec, typeMeta metav1.TypeMeta) (score scorecard.TestScore) {
-	pod := podTemplate.Spec
+func containerResourceRequestsEqualLimits(requireCPULimit bool) func(podTemplate corev1.PodTemplateSpec, typeMeta metav1.TypeMeta) (score scorecard.TestScore) {
+	return func(podTemplate corev1.PodTemplateSpec, typeMeta metav1.TypeMeta) (score scorecard.TestScore) {
+		pod := podTemplate.Spec
 
-	allContainers := pod.InitContainers
-	allContainers = append(allContainers, pod.Containers...)
+		allContainers := pod.InitContainers
+		allContainers = append(allContainers, pod.Containers...)
 
-	resourcesDoNotMatch := false
+		resourcesDoNotMatch := false
 
-	for _, container := range allContainers {
-		requests := &container.Resources.Requests
-		limits := &container.Resources.Limits
-		if !requests.Cpu().Equal(*limits.Cpu()) {
-			score.AddComment(container.Name, "CPU requests does not match limits", "Having equal requests and limits is recommended to avoid resource DDOS of the node during spikes. Set resources.requests.cpu == resources.limits.cpu")
-			resourcesDoNotMatch = true
+		for _, container := range allContainers {
+			requests := &container.Resources.Requests
+			limits := &container.Resources.Limits
+			if !requests.Cpu().Equal(*limits.Cpu()) && requireCPULimit {
+				score.AddComment(container.Name, "CPU requests does not match limits", "Having equal requests and limits is recommended to avoid resource DDOS of the node during spikes. Set resources.requests.cpu == resources.limits.cpu")
+				resourcesDoNotMatch = true
+			}
+			if !requests.Memory().Equal(*limits.Memory()) {
+				score.AddComment(container.Name, "Memory requests does not match limits", "Having equal requests and limits is recommended to avoid resource DDOS of the node during spikes. Set resources.requests.memory == resources.limits.memory")
+				resourcesDoNotMatch = true
+			}
 		}
-		if !requests.Memory().Equal(*limits.Memory()) {
-			score.AddComment(container.Name, "Memory requests does not match limits", "Having equal requests and limits is recommended to avoid resource DDOS of the node during spikes. Set resources.requests.memory == resources.limits.memory")
-			resourcesDoNotMatch = true
+
+		if resourcesDoNotMatch {
+			score.Grade = scorecard.GradeCritical
+		} else {
+			score.Grade = scorecard.GradeAllOK
 		}
-	}
 
-	if resourcesDoNotMatch {
-		score.Grade = scorecard.GradeCritical
-	} else {
-		score.Grade = scorecard.GradeAllOK
+		return
 	}
-
-	return
 }
 
 // containerImageTag checks that no container is using the ":latest" tag

--- a/score/container/container_test.go
+++ b/score/container/container_test.go
@@ -1,8 +1,9 @@
 package container
 
 import (
-	"k8s.io/apimachinery/pkg/api/resource"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -13,7 +14,8 @@ import (
 
 func TestOkAllTheSameContainerResourceRequestsEqualLimits(t *testing.T) {
 	t.Parallel()
-	s := containerResourceRequestsEqualLimits(
+	f := containerResourceRequestsEqualLimits(true)
+	s := f(
 		corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
@@ -41,7 +43,8 @@ func TestOkAllTheSameContainerResourceRequestsEqualLimits(t *testing.T) {
 
 func TestOkMultipleContainersContainerResourceRequestsEqualLimits(t *testing.T) {
 	t.Parallel()
-	s := containerResourceRequestsEqualLimits(
+	f := containerResourceRequestsEqualLimits(true)
+	s := f(
 		corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				InitContainers: []corev1.Container{
@@ -97,7 +100,8 @@ func TestOkMultipleContainersContainerResourceRequestsEqualLimits(t *testing.T) 
 
 func TestOkSameQuantityContainerResourceRequestsEqualLimits(t *testing.T) {
 	t.Parallel()
-	s := containerResourceRequestsEqualLimits(
+	f := containerResourceRequestsEqualLimits(true)
+	s := f(
 		corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
@@ -125,7 +129,8 @@ func TestOkSameQuantityContainerResourceRequestsEqualLimits(t *testing.T) {
 
 func TestFailBothContainerResourceRequestsEqualLimits(t *testing.T) {
 	t.Parallel()
-	s := containerResourceRequestsEqualLimits(
+	f := containerResourceRequestsEqualLimits(true)
+	s := f(
 		corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
@@ -159,7 +164,8 @@ func TestFailBothContainerResourceRequestsEqualLimits(t *testing.T) {
 
 func TestFailCpuInitContainerResourceRequestsEqualLimits(t *testing.T) {
 	t.Parallel()
-	s := containerResourceRequestsEqualLimits(
+	f := containerResourceRequestsEqualLimits(true)
+	s := f(
 		corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				InitContainers: []corev1.Container{
@@ -201,4 +207,80 @@ func TestFailCpuInitContainerResourceRequestsEqualLimits(t *testing.T) {
 	assert.Equal(t, "init", s.Comments[0].Path)
 	assert.Equal(t, "CPU requests does not match limits", s.Comments[0].Summary)
 	assert.Equal(t, "Having equal requests and limits is recommended to avoid resource DDOS of the node during spikes. Set resources.requests.cpu == resources.limits.cpu", s.Comments[0].Description)
+}
+
+func TestOkIgnoreCpuContainerResourceRequestsEqualLimits(t *testing.T) {
+	t.Parallel()
+	f := containerResourceRequestsEqualLimits(false)
+	s := f(
+		corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name: "init",
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								"cpu":    resource.MustParse("1"),
+								"memory": resource.MustParse("256Mi"),
+							},
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								"cpu":    resource.MustParse("2"),
+								"memory": resource.MustParse("256Mi"),
+							},
+						},
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name: "foo",
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								"cpu":    resource.MustParse("1"),
+								"memory": resource.MustParse("256Mi"),
+							},
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								"cpu":    resource.MustParse("1"),
+								"memory": resource.MustParse("256Mi"),
+							},
+						},
+					},
+				},
+			},
+		},
+		metav1.TypeMeta{})
+
+	assert.Equal(t, scorecard.GradeAllOK, s.Grade)
+	assert.Len(t, s.Comments, 0)
+}
+
+func TestFailIgnoreCpuContainerResourceRequestsEqualLimits(t *testing.T) {
+	t.Parallel()
+	f := containerResourceRequestsEqualLimits(false)
+	s := f(
+		corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "foo",
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								"cpu":    resource.MustParse("1"),
+								"memory": resource.MustParse("256Mi"),
+							},
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								"cpu":    resource.MustParse("2"),
+								"memory": resource.MustParse("512Mi"),
+							},
+						},
+					},
+				},
+			},
+		},
+		metav1.TypeMeta{})
+
+	assert.Equal(t, scorecard.GradeCritical, s.Grade)
+	assert.Len(t, s.Comments, 1)
+	assert.Equal(t, "foo", s.Comments[0].Path)
+	assert.Equal(t, "Memory requests does not match limits", s.Comments[0].Summary)
+	assert.Equal(t, "Having equal requests and limits is recommended to avoid resource DDOS of the node during spikes. Set resources.requests.memory == resources.limits.memory", s.Comments[0].Description)
 }

--- a/score/score_test.go
+++ b/score/score_test.go
@@ -100,6 +100,19 @@ func TestPodContainerResourceLimitCpuRequired(t *testing.T) {
 	}, "Container Resources", 1)
 }
 
+func TestPodContainerResourceRequestsEqualLimitsCpuNotRequired(t *testing.T) {
+	t.Parallel()
+
+	structMap := make(map[string]struct{})
+	structMap["container-resource-requests-equal-limits"] = struct{}{}
+
+	testExpectedScoreWithConfig(t, config.Configuration{
+		IgnoreContainerCpuLimitRequirement: true,
+		AllFiles:                           []io.Reader{testFile("pod-test-resources-limits-and-requests-no-cpu-limit.yaml")},
+		EnabledOptionalTests:               structMap,
+	}, "Container Resource Requests Equal Limits", 10)
+}
+
 func TestPodContainerResourceNoLimitRequired(t *testing.T) {
 	t.Parallel()
 	testExpectedScoreWithConfig(t, config.Configuration{


### PR DESCRIPTION
…-requests-equal-limits'

This fixes #233

```
RELNOTE: container-resource-requests-equal-limits now allows to ignore missing CPU limits with flag --ignore-container-cpu-limit
```
