### PR TITLE
parser: propagate error if input parsing fails after type detection

### DIFF
--- a/parser/error.go
+++ b/parser/error.go
@@ -1,0 +1,26 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+)
+
+type parseError []error
+
+func (p parseError) Error() string {
+	var s []string
+	for _, e := range p {
+		s = append(s, e.Error())
+	}
+	return fmt.Sprintf(strings.Join(s, "\n"))
+}
+
+func (p *parseError) AddIfErr(err error) {
+	if err != nil {
+		*p = append(*p, err)
+	}
+}
+
+func (p parseError) Any() bool {
+	return len(p) > 0
+}

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -2,8 +2,11 @@ package parser
 
 import (
 	"bytes"
-	"gopkg.in/yaml.v3"
+	"fmt"
 	"io/ioutil"
+	"log"
+
+	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
@@ -17,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"log"
 
 	"github.com/zegl/kube-score/config"
 	ks "github.com/zegl/kube-score/domain"
@@ -145,7 +147,10 @@ func detectAndDecode(cnf config.Configuration, s *parsedObjects, raw []byte) err
 	// Parse lists and their items recursively
 	if detectedVersion == corev1.SchemeGroupVersion.WithKind("List") {
 		var list corev1.List
-		decode(raw, &list)
+		err := decode(raw, &list)
+		if err != nil {
+			return err
+		}
 		for _, listItem := range list.Items {
 			err := detectAndDecode(cnf, s, listItem.Raw)
 			if err != nil {
@@ -155,118 +160,125 @@ func detectAndDecode(cnf config.Configuration, s *parsedObjects, raw []byte) err
 		return nil
 	}
 
-	decodeItem(cnf, s, detectedVersion, raw)
+	err = decodeItem(cnf, s, detectedVersion, raw)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
 
-func decode(data []byte, object runtime.Object) {
+func decode(data []byte, object runtime.Object) error {
 	deserializer := codecs.UniversalDeserializer()
 	if _, _, err := deserializer.Decode(data, nil, object); err != nil {
-		panic(err)
+		gvk := object.GetObjectKind().GroupVersionKind()
+		return fmt.Errorf("Failed to parse %s: err=%w", gvk, err)
 	}
+	return nil
 }
 
-func decodeItem(cnf config.Configuration, s *parsedObjects, detectedVersion schema.GroupVersionKind, fileContents []byte) {
+func decodeItem(cnf config.Configuration, s *parsedObjects, detectedVersion schema.GroupVersionKind, fileContents []byte) error {
 	addPodSpeccer := func(ps ks.PodSpecer) {
 		s.podspecers = append(s.podspecers, ps)
 		s.bothMetas = append(s.bothMetas, ks.BothMeta{ps.GetTypeMeta(), ps.GetObjectMeta()})
 	}
 
+	var errs parseError
+
 	switch detectedVersion {
 	case corev1.SchemeGroupVersion.WithKind("Pod"):
 		var pod corev1.Pod
-		decode(fileContents, &pod)
+		errs.AddIfErr(decode(fileContents, &pod))
 		s.pods = append(s.pods, pod)
 		s.bothMetas = append(s.bothMetas, ks.BothMeta{pod.TypeMeta, pod.ObjectMeta})
 
 	case batchv1.SchemeGroupVersion.WithKind("Job"):
 		var job batchv1.Job
-		decode(fileContents, &job)
+		errs.AddIfErr(decode(fileContents, &job))
 		addPodSpeccer(internal.Batchv1Job{job})
 
 	case batchv1beta1.SchemeGroupVersion.WithKind("CronJob"):
 		var cronjob batchv1beta1.CronJob
-		decode(fileContents, &cronjob)
+		errs.AddIfErr(decode(fileContents, &cronjob))
 		addPodSpeccer(internal.Batchv1beta1CronJob{cronjob})
 		s.cronjobs = append(s.cronjobs, cronjob)
 
 	case appsv1.SchemeGroupVersion.WithKind("Deployment"):
 		var deployment appsv1.Deployment
-		decode(fileContents, &deployment)
+		errs.AddIfErr(decode(fileContents, &deployment))
 		addPodSpeccer(internal.Appsv1Deployment{deployment})
 
 		// TODO: Support older versions of Deployment as well?
 		s.deployments = append(s.deployments, deployment)
 	case appsv1beta1.SchemeGroupVersion.WithKind("Deployment"):
 		var deployment appsv1beta1.Deployment
-		decode(fileContents, &deployment)
+		errs.AddIfErr(decode(fileContents, &deployment))
 		addPodSpeccer(internal.Appsv1beta1Deployment{deployment})
 	case appsv1beta2.SchemeGroupVersion.WithKind("Deployment"):
 		var deployment appsv1beta2.Deployment
-		decode(fileContents, &deployment)
+		errs.AddIfErr(decode(fileContents, &deployment))
 		addPodSpeccer(internal.Appsv1beta2Deployment{deployment})
 	case extensionsv1beta1.SchemeGroupVersion.WithKind("Deployment"):
 		var deployment extensionsv1beta1.Deployment
-		decode(fileContents, &deployment)
+		errs.AddIfErr(decode(fileContents, &deployment))
 		addPodSpeccer(internal.Extensionsv1beta1Deployment{deployment})
 
 	case appsv1.SchemeGroupVersion.WithKind("StatefulSet"):
 		var statefulSet appsv1.StatefulSet
-		decode(fileContents, &statefulSet)
+		errs.AddIfErr(decode(fileContents, &statefulSet))
 		addPodSpeccer(internal.Appsv1StatefulSet{statefulSet})
 
 		// TODO: Support older versions of StatefulSet as well?
 		s.statefulsets = append(s.statefulsets, statefulSet)
 	case appsv1beta1.SchemeGroupVersion.WithKind("StatefulSet"):
 		var statefulSet appsv1beta1.StatefulSet
-		decode(fileContents, &statefulSet)
+		errs.AddIfErr(decode(fileContents, &statefulSet))
 		addPodSpeccer(internal.Appsv1beta1StatefulSet{statefulSet})
 	case appsv1beta2.SchemeGroupVersion.WithKind("StatefulSet"):
 		var statefulSet appsv1beta2.StatefulSet
-		decode(fileContents, &statefulSet)
+		errs.AddIfErr(decode(fileContents, &statefulSet))
 		addPodSpeccer(internal.Appsv1beta2StatefulSet{statefulSet})
 
 	case appsv1.SchemeGroupVersion.WithKind("DaemonSet"):
 		var daemonset appsv1.DaemonSet
-		decode(fileContents, &daemonset)
+		errs.AddIfErr(decode(fileContents, &daemonset))
 		addPodSpeccer(internal.Appsv1DaemonSet{daemonset})
 	case appsv1beta2.SchemeGroupVersion.WithKind("DaemonSet"):
 		var daemonset appsv1beta2.DaemonSet
-		decode(fileContents, &daemonset)
+		errs.AddIfErr(decode(fileContents, &daemonset))
 		addPodSpeccer(internal.Appsv1beta2DaemonSet{daemonset})
 	case extensionsv1beta1.SchemeGroupVersion.WithKind("DaemonSet"):
 		var daemonset extensionsv1beta1.DaemonSet
-		decode(fileContents, &daemonset)
+		errs.AddIfErr(decode(fileContents, &daemonset))
 		addPodSpeccer(internal.Extensionsv1beta1DaemonSet{daemonset})
 
 	case networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"):
 		var netpol networkingv1.NetworkPolicy
-		decode(fileContents, &netpol)
+		errs.AddIfErr(decode(fileContents, &netpol))
 		s.networkPolicies = append(s.networkPolicies, netpol)
 		s.bothMetas = append(s.bothMetas, ks.BothMeta{netpol.TypeMeta, netpol.ObjectMeta})
 
 	case corev1.SchemeGroupVersion.WithKind("Service"):
 		var service corev1.Service
-		decode(fileContents, &service)
+		errs.AddIfErr(decode(fileContents, &service))
 		s.services = append(s.services, service)
 		s.bothMetas = append(s.bothMetas, ks.BothMeta{service.TypeMeta, service.ObjectMeta})
 
 	case policyv1beta1.SchemeGroupVersion.WithKind("PodDisruptionBudget"):
 		var disruptBudget policyv1beta1.PodDisruptionBudget
-		decode(fileContents, &disruptBudget)
+		errs.AddIfErr(decode(fileContents, &disruptBudget))
 		s.podDisruptionBudgets = append(s.podDisruptionBudgets, disruptBudget)
 		s.bothMetas = append(s.bothMetas, ks.BothMeta{disruptBudget.TypeMeta, disruptBudget.ObjectMeta})
 
 	case extensionsv1beta1.SchemeGroupVersion.WithKind("Ingress"):
 		var ingress extensionsv1beta1.Ingress
-		decode(fileContents, &ingress)
+		errs.AddIfErr(decode(fileContents, &ingress))
 		s.ingresses = append(s.ingresses, ingress)
 		s.bothMetas = append(s.bothMetas, ks.BothMeta{ingress.TypeMeta, ingress.ObjectMeta})
 
 	case autoscalingv1.SchemeGroupVersion.WithKind("HorizontalPodAutoscaler"):
 		var hpa autoscalingv1.HorizontalPodAutoscaler
-		decode(fileContents, &hpa)
+		errs.AddIfErr(decode(fileContents, &hpa))
 		s.horizontalPodAutoscalers = append(s.horizontalPodAutoscalers, hpa)
 		s.bothMetas = append(s.bothMetas, ks.BothMeta{hpa.TypeMeta, hpa.ObjectMeta})
 
@@ -275,4 +287,9 @@ func decodeItem(cnf config.Configuration, s *parsedObjects, detectedVersion sche
 			log.Printf("Unknown datatype: %s", detectedVersion.String())
 		}
 	}
+
+	if errs.Any() {
+		return errs
+	}
+	return nil
 }

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -1,0 +1,41 @@
+package parser
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/zegl/kube-score/config"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParse(t *testing.T) {
+
+	cases := []struct {
+		fname    string
+		expected error
+	}{
+		{
+			"testdata/invalid-yaml.yaml",
+			fmt.Errorf("Failed to parse /v1, Kind=Service: err=v1.Service.Spec: v1.ServiceSpec.Ports: []v1.ServicePort: v1.ServicePort.NodePort: readUint32: unexpected character: \xff, error found in #10 byte of ...|odePort\":\"${PORT}\",\"|..., bigger context ...|\"namespace\":\"test\"},\"spec\":{\"ports\":[{\"nodePort\":\"${PORT}\",\"port\":\"${PORT_EXPOSE}\",\"targetPort\":\"${P|..."),
+		}, {
+			"testdata/valid-yaml.yaml",
+			nil,
+		},
+	}
+
+	for _, tc := range cases {
+		fp, err := os.Open(tc.fname)
+		assert.Nil(t, err)
+		_, err = ParseFiles(config.Configuration{
+			AllFiles: []io.Reader{fp},
+		})
+		if tc.expected == nil {
+			assert.Nil(t, err)
+		} else {
+			assert.Equal(t, tc.expected.Error(), err.Error())
+		}
+	}
+}

--- a/parser/testdata/invalid-yaml.yaml
+++ b/parser/testdata/invalid-yaml.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${APP}-service
+  namespace: test
+spec:
+  type: NodePort
+  ports:
+  - port: ${PORT_EXPOSE}
+    targetPort: ${PORT_EXPOSE}
+    nodePort: ${PORT}
+  selector:
+    app: ${APP}

--- a/parser/testdata/valid-yaml.yaml
+++ b/parser/testdata/valid-yaml.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: xyz-service
+  namespace: test
+spec:
+  type: NodePort
+  ports:
+  - port: 123
+    targetPort: 4444
+    nodePort: 32444
+  selector:
+    app: xyz


### PR DESCRIPTION
<!--
    Optional: Add this change to the release notes by adding a RELNOTE comment
    If this shouldn't appear in the notes, simply remove this.
-->

```
RELNOTE: descriptive error messages if input parsing fails
```

Fixes #232