### PR TITLE
cmd: fix command-line subcommand parsing

### DIFF
--- a/cmd/kube-score/cmd.go
+++ b/cmd/kube-score/cmd.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+type cmdFunc func(string, []string)
+
+func parse(args []string, cmds map[string]cmdFunc) (command string, cmdArgsOffset int, err error) {
+	helpName := execName(args[0])
+
+	// When executing kube-score as a kubectl plugin, default to the "score" sub-command to avoid stuttering
+	// "kubectl score" is equivalent to "kubectl score score"
+	if isKubectlPlugin(helpName) {
+		command = "score"
+		cmdArgsOffset = 1
+	}
+
+	// No command, flag, or file has been specified
+	if len(args) <= cmdArgsOffset {
+		err = fmt.Errorf("No command, flag or file")
+		return
+	}
+
+	// If arg 1 is set and is a valid command, always use it as the command to execute, instead of the default
+	if _, ok := cmds[args[1]]; ok {
+		command = args[1]
+		cmdArgsOffset = 2
+	}
+	return
+}
+
+func execName(args0 string) string {
+	// Detect name of the binary
+	binName := path.Base(args0)
+
+	// If executed as a kubectl plugin, replace dash with a space
+	// "kubectl-score" -> "kubectl score"
+	if strings.HasPrefix(binName, "kubectl-") {
+		binName = strings.Replace(binName, "kubectl-", "kubectl ", 1)
+	}
+
+	return binName
+}
+
+func isKubectlPlugin(helpName string) bool {
+	return execName(helpName) == "kubectl score"
+}

--- a/cmd/kube-score/cmd_test.go
+++ b/cmd/kube-score/cmd_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseCli(t *testing.T) {
+	cmds := map[string]cmdFunc{
+		"a":     func(string, []string) {},
+		"b":     func(string, []string) {},
+		"score": func(string, []string) {},
+	}
+
+	cmd, offset, err := parse([]string{"kube-score", "a"}, cmds)
+	assert.Equal(t, "a", cmd)
+	assert.Equal(t, 2, offset)
+	assert.Nil(t, err)
+
+	cmd, offset, err = parse([]string{"kube-score", "unknown"}, cmds)
+	assert.Equal(t, "", cmd)
+	assert.Equal(t, 0, offset)
+	assert.Nil(t, err)
+
+	cmd, offset, err = parse([]string{"kubectl-score", "a"}, cmds)
+	assert.Equal(t, "a", cmd)
+	assert.Equal(t, 2, offset)
+	assert.Nil(t, err)
+
+	cmd, offset, err = parse([]string{"kubectl-score", "xyz.yaml"}, cmds)
+	assert.Equal(t, "score", cmd)
+	assert.Equal(t, 1, offset)
+	assert.Nil(t, err)
+
+	cmd, offset, err = parse([]string{"kubectl-score", "score", "xyz.yaml"}, cmds)
+	assert.Equal(t, "score", cmd)
+	assert.Equal(t, 2, offset)
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
This is a regression since #225 / v1.5.1

<!--
    Optional: Add this change to the release notes by adding a RELNOTE comment
    If this shouldn't appear in the notes, simply remove this.
-->

```
RELNOTE: fixes subcommand parsing which has been broken since v1.5.1
```
