### PR TITLE
Add new optional checks for CPU and memory requests equal limits

### DIFF
--- a/README_CHECKS.md
+++ b/README_CHECKS.md
@@ -5,6 +5,8 @@
 | cronjob-has-deadline | CronJob | Makes sure that all CronJobs has a configured deadline | default |
 | container-resources | Pod | Makes sure that all pods have resource limits and requests set. The --ignore-container-cpu-limit flag can be used to disable the requirement of having a CPU limit | default |
 | container-resource-requests-equal-limits | Pod | Makes sure that all pods have the same requests as limits on resources set. | optional |
+| container-cpu-requests-equal-limits | Pod | Makes sure that all pods have the same CPU requests as limits set. | optional |
+| container-memory-requests-equal-limits | Pod | Makes sure that all pods have the same memory requests as limits set. | optional |
 | container-image-tag | Pod | Makes sure that a explicit non-latest tag is used | default |
 | container-image-pull-policy | Pod | Makes sure that the pullPolicy is set to Always. This makes sure that imagePullSecrets are always validated. | default |
 | statefulset-has-poddisruptionbudget | StatefulSet | Makes sure that all StatefulSets are targeted by a PDB | default |

--- a/score/container/container.go
+++ b/score/container/container.go
@@ -13,6 +13,8 @@ import (
 func Register(allChecks *checks.Checks, cnf config.Configuration) {
 	allChecks.RegisterPodCheck("Container Resources", `Makes sure that all pods have resource limits and requests set. The --ignore-container-cpu-limit flag can be used to disable the requirement of having a CPU limit`, containerResources(!cnf.IgnoreContainerCpuLimitRequirement, !cnf.IgnoreContainerMemoryLimitRequirement))
 	allChecks.RegisterOptionalPodCheck("Container Resource Requests Equal Limits", `Makes sure that all pods have the same requests as limits on resources set.`, containerResourceRequestsEqualLimits)
+	allChecks.RegisterOptionalPodCheck("Container CPU Requests Equal Limits", `Makes sure that all pods have the same CPU requests as limits set.`, containerCPURequestsEqualLimits)
+	allChecks.RegisterOptionalPodCheck("Container Memory Requests Equal Limits", `Makes sure that all pods have the same memory requests as limits set.`, containerMemoryRequestsEqualLimits)
 	allChecks.RegisterPodCheck("Container Image Tag", `Makes sure that a explicit non-latest tag is used`, containerImageTag)
 	allChecks.RegisterPodCheck("Container Image Pull Policy", `Makes sure that the pullPolicy is set to Always. This makes sure that imagePullSecrets are always validated.`, containerImagePullPolicy)
 }
@@ -65,6 +67,24 @@ func containerResources(requireCPULimit bool, requireMemoryLimit bool) func(core
 
 // containerResourceRequestsEqualLimits checks that all containers have equal requests and limits for CPU and memory resources
 func containerResourceRequestsEqualLimits(podTemplate corev1.PodTemplateSpec, typeMeta metav1.TypeMeta) (score scorecard.TestScore) {
+	cpuScore := containerCPURequestsEqualLimits(podTemplate, typeMeta)
+	memoryScore := containerMemoryRequestsEqualLimits(podTemplate, typeMeta)
+
+	score.Grade = scorecard.GradeAllOK
+	if cpuScore.Grade == scorecard.GradeCritical {
+		score.Grade = scorecard.GradeCritical
+		score.Comments = append(score.Comments, cpuScore.Comments...)
+	}
+	if memoryScore.Grade == scorecard.GradeCritical {
+		score.Grade = scorecard.GradeCritical
+		score.Comments = append(score.Comments, memoryScore.Comments...)
+	}
+
+	return score
+}
+
+// containerCPURequestsEqualLimits checks that all containers have equal requests and limits for CPU resources
+func containerCPURequestsEqualLimits(podTemplate corev1.PodTemplateSpec, typeMeta metav1.TypeMeta) (score scorecard.TestScore) {
 	pod := podTemplate.Spec
 
 	allContainers := pod.InitContainers
@@ -79,6 +99,29 @@ func containerResourceRequestsEqualLimits(podTemplate corev1.PodTemplateSpec, ty
 			score.AddComment(container.Name, "CPU requests does not match limits", "Having equal requests and limits is recommended to avoid resource DDOS of the node during spikes. Set resources.requests.cpu == resources.limits.cpu")
 			resourcesDoNotMatch = true
 		}
+	}
+
+	if resourcesDoNotMatch {
+		score.Grade = scorecard.GradeCritical
+	} else {
+		score.Grade = scorecard.GradeAllOK
+	}
+
+	return
+}
+
+// containerMemoryRequestsEqualLimits checks that all containers have equal requests and limits for memory resources
+func containerMemoryRequestsEqualLimits(podTemplate corev1.PodTemplateSpec, typeMeta metav1.TypeMeta) (score scorecard.TestScore) {
+	pod := podTemplate.Spec
+
+	allContainers := pod.InitContainers
+	allContainers = append(allContainers, pod.Containers...)
+
+	resourcesDoNotMatch := false
+
+	for _, container := range allContainers {
+		requests := &container.Resources.Requests
+		limits := &container.Resources.Limits
 		if !requests.Memory().Equal(*limits.Memory()) {
 			score.AddComment(container.Name, "Memory requests does not match limits", "Having equal requests and limits is recommended to avoid resource DDOS of the node during spikes. Set resources.requests.memory == resources.limits.memory")
 			resourcesDoNotMatch = true

--- a/score/container/container_test.go
+++ b/score/container/container_test.go
@@ -202,3 +202,358 @@ func TestFailCpuInitContainerResourceRequestsEqualLimits(t *testing.T) {
 	assert.Equal(t, "CPU requests does not match limits", s.Comments[0].Summary)
 	assert.Equal(t, "Having equal requests and limits is recommended to avoid resource DDOS of the node during spikes. Set resources.requests.cpu == resources.limits.cpu", s.Comments[0].Description)
 }
+
+func TestOkAllCPURequestsEqualLimits(t *testing.T) {
+	t.Parallel()
+	s := containerCPURequestsEqualLimits(
+		corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "foo",
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								"cpu": resource.MustParse("1"),
+							},
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								"cpu": resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+		},
+		metav1.TypeMeta{})
+
+	assert.Equal(t, scorecard.GradeAllOK, s.Grade)
+	assert.Len(t, s.Comments, 0)
+}
+
+func TestOkMultipleContainersContainerCPURequestsEqualLimits(t *testing.T) {
+	t.Parallel()
+	s := containerCPURequestsEqualLimits(
+		corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name: "foo",
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								"cpu": resource.MustParse("1"),
+							},
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								"cpu": resource.MustParse("1"),
+							},
+						},
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name: "foo",
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								"cpu": resource.MustParse("1"),
+							},
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								"cpu": resource.MustParse("1"),
+							},
+						},
+					},
+					{
+						Name: "foo2",
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								"cpu": resource.MustParse("1"),
+							},
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								"cpu": resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+		},
+		metav1.TypeMeta{})
+
+	assert.Equal(t, scorecard.GradeAllOK, s.Grade)
+	assert.Len(t, s.Comments, 0)
+}
+
+func TestOkSameQuantityContainerCPURequestsEqualLimits(t *testing.T) {
+	t.Parallel()
+	s := containerCPURequestsEqualLimits(
+		corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "foo",
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								"cpu": resource.MustParse("1"),
+							},
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								"cpu": resource.MustParse("1000m"),
+							},
+						},
+					},
+				},
+			},
+		},
+		metav1.TypeMeta{})
+
+	assert.Equal(t, scorecard.GradeAllOK, s.Grade)
+	assert.Len(t, s.Comments, 0)
+}
+
+func TestFailContainerCPURequestsEqualLimits(t *testing.T) {
+	t.Parallel()
+	s := containerCPURequestsEqualLimits(
+		corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "foo",
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								"cpu":    resource.MustParse("1"),
+								"memory": resource.MustParse("256Mi"),
+							},
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								"cpu":    resource.MustParse("2"),
+								"memory": resource.MustParse("512Mi"),
+							},
+						},
+					},
+				},
+			},
+		},
+		metav1.TypeMeta{})
+
+	assert.Equal(t, scorecard.GradeCritical, s.Grade)
+	assert.Len(t, s.Comments, 1)
+	assert.Equal(t, "foo", s.Comments[0].Path)
+	assert.Equal(t, "CPU requests does not match limits", s.Comments[0].Summary)
+	assert.Equal(t, "Having equal requests and limits is recommended to avoid resource DDOS of the node during spikes. Set resources.requests.cpu == resources.limits.cpu", s.Comments[0].Description)
+
+}
+
+func TestFailInitContainerCPURequestsEqualLimits(t *testing.T) {
+	t.Parallel()
+	s := containerCPURequestsEqualLimits(
+		corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name: "init",
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								"cpu": resource.MustParse("1"),
+							},
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								"cpu": resource.MustParse("2"),
+							},
+						},
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name: "foo",
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								"cpu":    resource.MustParse("1"),
+								"memory": resource.MustParse("256Mi"),
+							},
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								"cpu":    resource.MustParse("1"),
+								"memory": resource.MustParse("256Mi"),
+							},
+						},
+					},
+				},
+			},
+		},
+		metav1.TypeMeta{})
+
+	assert.Equal(t, scorecard.GradeCritical, s.Grade)
+	assert.Len(t, s.Comments, 1)
+	assert.Equal(t, "init", s.Comments[0].Path)
+	assert.Equal(t, "CPU requests does not match limits", s.Comments[0].Summary)
+	assert.Equal(t, "Having equal requests and limits is recommended to avoid resource DDOS of the node during spikes. Set resources.requests.cpu == resources.limits.cpu", s.Comments[0].Description)
+}
+
+func TestOkContainerMemoryResourceRequestsEqualLimits(t *testing.T) {
+	t.Parallel()
+	s := containerMemoryRequestsEqualLimits(
+		corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "foo",
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								"memory": resource.MustParse("256Mi"),
+							},
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								"memory": resource.MustParse("256Mi"),
+							},
+						},
+					},
+				},
+			},
+		},
+		metav1.TypeMeta{})
+
+	assert.Equal(t, scorecard.GradeAllOK, s.Grade)
+	assert.Len(t, s.Comments, 0)
+}
+
+func TestOkMultipleContainersContainerMemoryRequestsEqualLimits(t *testing.T) {
+	t.Parallel()
+	s := containerMemoryRequestsEqualLimits(
+		corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name: "foo",
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								"memory": resource.MustParse("256Mi"),
+							},
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								"memory": resource.MustParse("256Mi"),
+							},
+						},
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name: "foo",
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								"memory": resource.MustParse("256Mi"),
+							},
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								"memory": resource.MustParse("256Mi"),
+							},
+						},
+					},
+					{
+						Name: "foo2",
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								"memory": resource.MustParse("256Mi"),
+							},
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								"memory": resource.MustParse("256Mi"),
+							},
+						},
+					},
+				},
+			},
+		},
+		metav1.TypeMeta{})
+
+	assert.Equal(t, scorecard.GradeAllOK, s.Grade)
+	assert.Len(t, s.Comments, 0)
+}
+
+func TestOkSameQuantityContainerMemoryRequestsEqualLimits(t *testing.T) {
+	t.Parallel()
+	s := containerMemoryRequestsEqualLimits(
+		corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "foo",
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								"memory": resource.MustParse("256Mi"),
+							},
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								"memory": resource.MustParse("0.25Gi"),
+							},
+						},
+					},
+				},
+			},
+		},
+		metav1.TypeMeta{})
+
+	assert.Equal(t, scorecard.GradeAllOK, s.Grade)
+	assert.Len(t, s.Comments, 0)
+}
+
+func TestFailContainerMemoryRequestsEqualLimits(t *testing.T) {
+	t.Parallel()
+	s := containerMemoryRequestsEqualLimits(
+		corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "foo",
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								"cpu":    resource.MustParse("1"),
+								"memory": resource.MustParse("256Mi"),
+							},
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								"cpu":    resource.MustParse("2"),
+								"memory": resource.MustParse("512Mi"),
+							},
+						},
+					},
+				},
+			},
+		},
+		metav1.TypeMeta{})
+
+	assert.Equal(t, scorecard.GradeCritical, s.Grade)
+	assert.Len(t, s.Comments, 1)
+	assert.Equal(t, "foo", s.Comments[0].Path)
+	assert.Equal(t, "Memory requests does not match limits", s.Comments[0].Summary)
+	assert.Equal(t, "Having equal requests and limits is recommended to avoid resource DDOS of the node during spikes. Set resources.requests.memory == resources.limits.memory", s.Comments[0].Description)
+}
+
+func TestFailInitContainerMemoryRequestsEqualLimits(t *testing.T) {
+	t.Parallel()
+	s := containerMemoryRequestsEqualLimits(
+		corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name: "init",
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								"memory": resource.MustParse("256Mi"),
+							},
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								"memory": resource.MustParse("512Mi"),
+							},
+						},
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name: "foo",
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								"cpu":    resource.MustParse("1"),
+								"memory": resource.MustParse("256Mi"),
+							},
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								"cpu":    resource.MustParse("1"),
+								"memory": resource.MustParse("256Mi"),
+							},
+						},
+					},
+				},
+			},
+		},
+		metav1.TypeMeta{})
+
+	assert.Equal(t, scorecard.GradeCritical, s.Grade)
+	assert.Len(t, s.Comments, 1)
+	assert.Equal(t, "init", s.Comments[0].Path)
+	assert.Equal(t, "Memory requests does not match limits", s.Comments[0].Summary)
+	assert.Equal(t, "Having equal requests and limits is recommended to avoid resource DDOS of the node during spikes. Set resources.requests.memory == resources.limits.memory", s.Comments[0].Description)
+}

--- a/score/score_test.go
+++ b/score/score_test.go
@@ -109,6 +109,78 @@ func TestPodContainerResourceNoLimitRequired(t *testing.T) {
 	}, "Container Resources", 10)
 }
 
+func TestPodContainerResourceRequestsEqualLimits(t *testing.T) {
+	t.Parallel()
+
+	structMap := make(map[string]struct{})
+	structMap["container-resource-requests-equal-limits"] = struct{}{}
+
+	testExpectedScoreWithConfig(t, config.Configuration{
+		AllFiles:             []io.Reader{testFile("pod-test-resources-limits-and-requests.yaml")},
+		EnabledOptionalTests: structMap,
+	}, "Container Resource Requests Equal Limits", 10)
+}
+
+func TestPodContainerMemoryRequestsEqualLimits(t *testing.T) {
+	t.Parallel()
+
+	structMap := make(map[string]struct{})
+	structMap["container-memory-requests-equal-limits"] = struct{}{}
+
+	testExpectedScoreWithConfig(t, config.Configuration{
+		AllFiles:             []io.Reader{testFile("pod-test-resources-limits-and-requests.yaml")},
+		EnabledOptionalTests: structMap,
+	}, "Container Memory Requests Equal Limits", 10)
+}
+
+func TestPodContainerCPURequestsEqualLimits(t *testing.T) {
+	t.Parallel()
+
+	structMap := make(map[string]struct{})
+	structMap["container-cpu-requests-equal-limits"] = struct{}{}
+
+	testExpectedScoreWithConfig(t, config.Configuration{
+		AllFiles:             []io.Reader{testFile("pod-test-resources-limits-and-requests.yaml")},
+		EnabledOptionalTests: structMap,
+	}, "Container CPU Requests Equal Limits", 10)
+}
+
+func TestPodContainerResourceRequestsEqualLimitsNoLimits(t *testing.T) {
+	t.Parallel()
+
+	structMap := make(map[string]struct{})
+	structMap["container-resource-requests-equal-limits"] = struct{}{}
+
+	testExpectedScoreWithConfig(t, config.Configuration{
+		AllFiles:             []io.Reader{testFile("pod-test-resources-no-limits.yaml")},
+		EnabledOptionalTests: structMap,
+	}, "Container Resource Requests Equal Limits", 1)
+}
+
+func TestPodContainerMemoryRequestsEqualLimitsNoLimits(t *testing.T) {
+	t.Parallel()
+
+	structMap := make(map[string]struct{})
+	structMap["container-memory-requests-equal-limits"] = struct{}{}
+
+	testExpectedScoreWithConfig(t, config.Configuration{
+		AllFiles:             []io.Reader{testFile("pod-test-resources-no-limits.yaml")},
+		EnabledOptionalTests: structMap,
+	}, "Container Memory Requests Equal Limits", 1)
+}
+
+func TestPodContainerCPURequestsEqualLimitsNoLimits(t *testing.T) {
+	t.Parallel()
+
+	structMap := make(map[string]struct{})
+	structMap["container-cpu-requests-equal-limits"] = struct{}{}
+
+	testExpectedScoreWithConfig(t, config.Configuration{
+		AllFiles:             []io.Reader{testFile("pod-test-resources-no-limits.yaml")},
+		EnabledOptionalTests: structMap,
+	}, "Container CPU Requests Equal Limits", 1)
+}
+
 func TestDeploymentResources(t *testing.T) {
 	t.Parallel()
 	testExpectedScore(t, "deployment-test-resources.yaml", "Container Resources", 5)


### PR DESCRIPTION
```
RELNOTE: Added new optional checks container-cpu-requests-equal-limits and container-memory-requests-equal-limits to allow for checking for CPU and memory resources separately
```
This fixes #233