### PR TITLE
Updates to probes criticality

### DIFF
--- a/README_PROBES.md
+++ b/README_PROBES.md
@@ -24,8 +24,9 @@ Without a readinessProbe you're risking that:
 Every application that is targeted by a Service to:
 
 * Setup a readinessProbe that responds with a healthy status when: The application is fully booted, and ready to serve traffic.
-* Handle shutdowns gracefully: Applications should start to fail the readinessProbe after receiving `SIGTERM`, and _wait_ until the service is unregistered from all Load Balancers, before shutting down.
 * Set `interval` (default: 10s), `timeout` (default: 1s), `successThreshold` (default: 1), `failureThreshold` (default: 3) to your needs. In the default configuration, your application will fail for 30s (+ the time it takes for the network to react), for clients to stop sending traffic to your application.
+* Don't depend on downstream dependencies, such as other services or databases in your probe. If the dependency has a hickup, or for example, a database is restarted, removing your Pods from the Load Balancers rotation will likely only make the downtime worse.
+* Handle shutdowns gracefully: Applications should start to fail the readinessProbe after receiving `SIGTERM`, and _wait_ until the service is unregistered from all Load Balancers, before shutting down. As an alternative to this, a [`preStop`](https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/#define-poststart-and-prestop-handlers) hook with a sleep can be used. 
 
 ### `livenessProbe`
 
@@ -33,17 +34,30 @@ This probe roughly answers the question
 
 > Is the _container_ healthy right now, or do we need to restart it?
 
+It can be used to let Kubernetes know if your application is deadlocked, and needs to be restarted. Only the container with the failing probe will be restarted, other containers in the same Pod will be unaffected.
+
 **kube-score recommends**:
 
-Only touch this configuration if you know what you're doing.
+* If you don't know why you need a livenessProbe, don't configure it.
+* It should _never_, be the same as your `readinessProbe`.
+* The livenessProbe should *never* depend on downstream dependencies, such as databases or other services.
 
-It should _never_, be the same as your `readinessProbe`.
-
-// TODO
 
 ### `startupProbe` (alpha since v1.16, beta since v1.17)
 
-// TODO
+This probe roughly answers the question
+
+> Should we start running the livenessProbe now?
+
+For applications that take a longer time to boot than the livenessProbes `initialDelaySeconds` + `periodSeconds` * `failureThreshold`, a `startupProbe` can be configured.
+
+The startupProbe allows you to decrease the liveness probes `initialDelaySeconds`, and catch application deadlocks earlier.
+
+As soon as the startupProbe has succeeded once, the livenessProbe will start to be executed.
+
+**kube-score recommends**:
+
+* Configure a startupProbe if you have a livenessProbe configured. 
 
 ## Further reading
 

--- a/README_PROBES.md
+++ b/README_PROBES.md
@@ -1,0 +1,52 @@
+# Readiness and Liveness Probes
+
+Kubernetes supports three types of probes, that all serve different purposes, and have different pros and cons.
+
+This article is here to describe what recommendations kube-score will make in what cituations.
+
+## Different probe types
+
+### `readinessProbe`
+
+This probe roughly answers the question
+
+> Is it a good idea to send traffic to this Pod right now?
+
+A common *misunderstanding* is that, since Kubernetes manages the Pods, you don't need to do graceful draining of Pods during shutdown.
+
+Without a readinessProbe you're risking that:
+
+* Traffic is sent to the Pod before the server has started.
+* Traffic is still sent to the Pod _after_ the Pod has stopped. 
+
+**kube-score recommends**:
+
+Every application that is targeted by a Service to:
+
+* Setup a readinessProbe that responds with a healthy status when: The application is fully booted, and ready to serve traffic.
+* Handle shutdowns gracefully: Applications should start to fail the readinessProbe after receiving `SIGTERM`, and _wait_ until the service is unregistered from all Load Balancers, before shutting down.
+* Set `interval` (default: 10s), `timeout` (default: 1s), `successThreshold` (default: 1), `failureThreshold` (default: 3) to your needs. In the default configuration, your application will fail for 30s (+ the time it takes for the network to react), for clients to stop sending traffic to your application.
+
+### `livenessProbe`
+
+This probe roughly answers the question
+
+> Is the _container_ healthy right now, or do we need to restart it?
+
+**kube-score recommends**:
+
+Only touch this configuration if you know what you're doing.
+
+It should _never_, be the same as your `readinessProbe`.
+
+// TODO
+
+### `startupProbe` (alpha since v1.16, beta since v1.17)
+
+// TODO
+
+## Further reading
+
+* [Pod Lifecycle, kubernetes.io](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes)
+* [Configure Liveness, Readiness and Startup Probes, kubernetes.io](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
+* [Liveness probes are dangerous, srcco.de](https://srcco.de/posts/kubernetes-liveness-probes-are-dangerous.html)

--- a/renderer/human/human.go
+++ b/renderer/human/human.go
@@ -108,6 +108,11 @@ func outputHumanStep(card scorecard.TestScore, verboseOutput int, termWidth int)
 			fmt.Fprintf(w, wordwrap.Indent(wrapped, strings.Repeat(" ", 12), false))
 		}
 
+		if len(comment.DocumentationURL) > 0 {
+			fmt.Fprintln(w)
+			fmt.Fprintf(w, "%sMore information: %s", strings.Repeat(" ", 12), comment.DocumentationURL)
+		}
+
 		fmt.Fprintln(w)
 	}
 

--- a/renderer/human/output_test.go
+++ b/renderer/human/output_test.go
@@ -26,8 +26,9 @@ func getTestCard() *scorecard.Scorecard {
 				},
 				{
 					// No path
-					Summary:     "summary",
-					Description: "description",
+					Summary:          "summary",
+					Description:      "description",
+					DocumentationURL: "https://kube-score.com/whatever",
 				},
 			},
 		},
@@ -103,12 +104,14 @@ func TestHumanOutputDefault(t *testing.T) {
             description
         路 summary
             description
+            More information: https://kube-score.com/whatever
 v1/Testing bar-no-namespace                                                   馃
     [WARNING] test-warning-two-comments
         路 a -> summary
             description
         路 summary
             description
+            More information: https://kube-score.com/whatever
 `, string(all))
 }
 
@@ -123,6 +126,7 @@ func TestHumanOutputVerbose1(t *testing.T) {
             description
         路 summary
             description
+            More information: https://kube-score.com/whatever
     [OK] test-ok-comment
         路 a -> summary
             description
@@ -132,6 +136,7 @@ v1/Testing bar-no-namespace                                                   馃
             description
         路 summary
             description
+            More information: https://kube-score.com/whatever
     [OK] test-ok-comment
         路 a -> summary
             description
@@ -149,6 +154,7 @@ func TestHumanOutputVerbose2(t *testing.T) {
             description
         路 summary
             description
+            More information: https://kube-score.com/whatever
     [OK] test-ok-comment
         路 a -> summary
             description
@@ -162,6 +168,7 @@ v1/Testing bar-no-namespace                                                   馃
             description
         路 summary
             description
+            More information: https://kube-score.com/whatever
     [OK] test-ok-comment
         路 a -> summary
             description

--- a/score/probe_test.go
+++ b/score/probe_test.go
@@ -3,68 +3,71 @@ package score
 import (
 	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/zegl/kube-score/scorecard"
 )
 
 func TestProbesPodAllMissing(t *testing.T) {
 	t.Parallel()
-	comments := testExpectedScore(t, "pod-probes-all-missing.yaml", "Pod Probes", 1)
-	assert.Len(t, comments, 2)
+	comments := testExpectedScore(t, "pod-probes-all-missing.yaml", "Pod Probes", scorecard.GradeCritical)
+	assert.Len(t, comments, 1)
 	assert.Equal(t, "Container is missing a readinessProbe", comments[0].Summary)
-	assert.Equal(t, "Container is missing a livenessProbe", comments[1].Summary)
 }
 
 func TestProbesPodMissingReady(t *testing.T) {
 	t.Parallel()
-	// not targeted by service, expected full score
-	comments := testExpectedScore(t, "pod-probes-missing-ready.yaml", "Pod Probes", 10)
-	assert.Len(t, comments, 0)
+	comments := testExpectedScore(t, "pod-probes-missing-ready.yaml", "Pod Probes", scorecard.GradeCritical)
+	assert.Len(t, comments, 1)
+	assert.Equal(t, "Container is missing a readinessProbe", comments[0].Summary)
 }
 
 func TestProbesPodIdenticalHTTP(t *testing.T) {
 	t.Parallel()
-	comments := testExpectedScore(t, "pod-probes-identical-http.yaml", "Pod Probes", 7)
+	comments := testExpectedScore(t, "pod-probes-identical-http.yaml", "Pod Probes", scorecard.GradeCritical)
 	assert.Len(t, comments, 1)
-	assert.Equal(t, "Pod has the same readiness and liveness probe", comments[0].Summary)
+	assert.Equal(t, "Container has the same readiness and liveness probe", comments[0].Summary)
 }
 
 func TestProbesPodIdenticalTCP(t *testing.T) {
 	t.Parallel()
-	comments := testExpectedScore(t, "pod-probes-identical-tcp.yaml", "Pod Probes", 7)
+	comments := testExpectedScore(t, "pod-probes-identical-tcp.yaml", "Pod Probes", scorecard.GradeCritical)
 	assert.Len(t, comments, 1)
-	assert.Equal(t, "Pod has the same readiness and liveness probe", comments[0].Summary)
+	assert.Equal(t, "Container has the same readiness and liveness probe", comments[0].Summary)
 }
 
 func TestProbesPodIdenticalExec(t *testing.T) {
 	t.Parallel()
-	comments := testExpectedScore(t, "pod-probes-identical-exec.yaml", "Pod Probes", 7)
+	comments := testExpectedScore(t, "pod-probes-identical-exec.yaml", "Pod Probes", scorecard.GradeCritical)
 	assert.Len(t, comments, 1)
-	assert.Equal(t, "Pod has the same readiness and liveness probe", comments[0].Summary)
+	assert.Equal(t, "Container has the same readiness and liveness probe", comments[0].Summary)
 }
 
 func TestProbesTargetedByService(t *testing.T) {
 	t.Parallel()
-	comments := testExpectedScore(t, "pod-probes-targeted-by-service.yaml", "Pod Probes", 1)
+	comments := testExpectedScore(t, "pod-probes-targeted-by-service.yaml", "Pod Probes", scorecard.GradeCritical)
 	assert.Len(t, comments, 1)
 	assert.Equal(t, "Container is missing a readinessProbe", comments[0].Summary)
 }
 
 func TestProbesTargetedByServiceSameNamespace(t *testing.T) {
 	t.Parallel()
-	comments := testExpectedScore(t, "pod-probes-targeted-by-service-same-namespace.yaml", "Pod Probes", 1)
+	comments := testExpectedScore(t, "pod-probes-targeted-by-service-same-namespace.yaml", "Pod Probes", scorecard.GradeCritical)
 	assert.Len(t, comments, 1)
 	assert.Equal(t, "Container is missing a readinessProbe", comments[0].Summary)
 }
 
 func TestProbesTargetedByServiceDifferentNamespace(t *testing.T) {
 	t.Parallel()
-	comments := testExpectedScore(t, "pod-probes-targeted-by-service-different-namespace.yaml", "Pod Probes", 10)
-	assert.Len(t, comments, 0)
+	comments := testExpectedScore(t, "pod-probes-targeted-by-service-different-namespace.yaml", "Pod Probes", scorecard.GradeAllOK)
+	assert.Len(t, comments, 1)
+	assert.Equal(t, "The pod is not targeted by a service, skipping probe checks.", comments[0].Summary)
 }
 
 func TestProbesTargetedByServiceNotTargeted(t *testing.T) {
 	t.Parallel()
 	comments := testExpectedScore(t, "pod-probes-not-targeted-by-service.yaml", "Pod Probes", 10)
-	assert.Len(t, comments, 0)
+	assert.Len(t, comments, 1)
+	assert.Equal(t, "The pod is not targeted by a service, skipping probe checks.", comments[0].Summary)
 }
 
 func TestProbesMultipleContainers(t *testing.T) {

--- a/score/testdata/pod-probes-all-missing.yaml
+++ b/score/testdata/pod-probes-all-missing.yaml
@@ -2,7 +2,21 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod-test-1
+  labels:
+    app: test
 spec:
   containers:
   - name: foobar
     image: foo/bar:latest
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: test
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/score/testdata/pod-probes-both.yaml
+++ b/score/testdata/pod-probes-both.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod-test-1
+  labels:
+    app: test
 spec:
   containers:
   - name: foobar
@@ -14,3 +16,15 @@ spec:
       httpGet:
         path: /live
         port: 8080
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: test
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/score/testdata/pod-probes-identical-exec.yaml
+++ b/score/testdata/pod-probes-identical-exec.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod-test-1
+  labels:
+    app: test
 spec:
   containers:
   - name: foobar
@@ -16,3 +18,15 @@ spec:
         command:
         - "abc"
         - "123"
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: test
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/score/testdata/pod-probes-identical-http.yaml
+++ b/score/testdata/pod-probes-identical-http.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod-test-1
+  labels:
+    app: test
 spec:
   containers:
   - name: foobar
@@ -14,3 +16,16 @@ spec:
       httpGet:
         path: /ready
         port: 8080
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: test
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/score/testdata/pod-probes-identical-tcp.yaml
+++ b/score/testdata/pod-probes-identical-tcp.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod-test-1
+  labels:
+    app: test
 spec:
   containers:
   - name: foobar
@@ -12,3 +14,15 @@ spec:
     livenessProbe:
       tcpSocket:
         port: 8080
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: test
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/score/testdata/pod-probes-missing-live.yaml
+++ b/score/testdata/pod-probes-missing-live.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod-test-1
+  labels:
+    app: test
 spec:
   containers:
   - name: foobar
@@ -10,3 +12,16 @@ spec:
       httpGet:
         path: /ready
         port: 8080
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: test
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/score/testdata/pod-probes-missing-ready.yaml
+++ b/score/testdata/pod-probes-missing-ready.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod-test-1
+  labels:
+    app: test
 spec:
   containers:
   - name: foobar
@@ -10,3 +12,16 @@ spec:
       httpGet:
         path: /live
         port: 8080
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: test
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/score/testdata/pod-probes-on-different-containers-init.yaml
+++ b/score/testdata/pod-probes-on-different-containers-init.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod-test-1
+  labels:
+    app: test
 spec:
   initContainers:
   - name: foobar2
@@ -17,3 +19,16 @@ spec:
       httpGet:
         path: /live
         port: 8080
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: test
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/score/testdata/pod-probes-on-different-containers.yaml
+++ b/score/testdata/pod-probes-on-different-containers.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod-test-1
+  labels:
+    app: test
 spec:
   containers:
   - name: foobar
@@ -16,3 +18,16 @@ spec:
         port: 8080
   - name: foobar2
     image: foo/bar:latest
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: test
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/scorecard/scorecard.go
+++ b/scorecard/scorecard.go
@@ -130,9 +130,10 @@ func (g Grade) String() string {
 }
 
 type TestScoreComment struct {
-	Path        string
-	Summary     string
-	Description string
+	Path             string
+	Summary          string
+	Description      string
+	DocumentationURL string
 }
 
 func (ts *TestScore) AddComment(path, summary, description string) {
@@ -140,5 +141,14 @@ func (ts *TestScore) AddComment(path, summary, description string) {
 		Path:        path,
 		Summary:     summary,
 		Description: description,
+	})
+}
+
+func (ts *TestScore) AddCommentWithURL(path, summary, description, documentationURL string) {
+	ts.Comments = append(ts.Comments, TestScoreComment{
+		Path:             path,
+		Summary:          summary,
+		Description:      description,
+		DocumentationURL: documentationURL,
 	})
 }


### PR DESCRIPTION
```
RELNOTE: The criticality for missing and identical probes have changed. A missing livenessProbe is now AlmostOK (was Warning). Identical probes are now Critical (was AlmostOK). See the new README_PROBES.md document for more information. kube-score can now also output links to documentation on failure.
```

This fixes #249
