### PR TITLE
Add instructions for running with Docker and modify Dockerfile to make command more intuitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ kubectl api-resources --verbs=list --namespaced -o name \
   | kube-score score -
 ```
 
+### Example with Docker
+
+```bash
+docker run -v $(pwd):/project zegl/kube-score:v1.7.0 score my-app/*.yaml
+```
+
 ## Configuration
 
 ```

--- a/cmd/kube-score/Dockerfile
+++ b/cmd/kube-score/Dockerfile
@@ -1,3 +1,4 @@
 FROM scratch
 COPY kube-score /
+WORKDIR /project
 ENTRYPOINT ["/kube-score"]


### PR DESCRIPTION
Based on your comments in [issue 203](https://github.com/zegl/kube-score/issues/203), I modified the Dockerfile to make the /project directory the WORKDIR so the user didn't have to prepend the yaml files to be tested with /project.

Additionally, I added a note in the README to show how to use kube-score from Docker

<!--
    Optional: Add this change to the release notes by adding a RELNOTE comment
    If this shouldn't appear in the notes, simply remove this.
-->

```
RELNOTE: Modify Dockerfile to add WORKDIR and add instructions to README.md for how to run kube-score using Docker
```
