### PR TITLE
Forward CronJob Namespace properly

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -198,6 +198,7 @@ k8s.io/apimachinery v0.18.0/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftc
 k8s.io/apimachinery v0.18.1/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
 k8s.io/apimachinery v0.18.2 h1:44CmtbmkzVDAhCpRVSiP2R5PPrC2RtlIv/MoB8xpdRA=
 k8s.io/apimachinery v0.18.2/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
+k8s.io/apimachinery v0.18.3 h1:pOGcbVAhxADgUYnjS08EFXs9QMl8qaH5U4fr5LGUrSk=
 k8s.io/apimachinery v0.18.3/go.mod h1:OaXp26zu/5J7p0f92ASynJa1pZo06YlV9fG7BoWbCko=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=

--- a/parser/internal/jobs.go
+++ b/parser/internal/jobs.go
@@ -37,6 +37,7 @@ func (d Batchv1beta1CronJob) GetObjectMeta() metav1.ObjectMeta {
 }
 
 func (d Batchv1beta1CronJob) GetPodTemplateSpec() corev1.PodTemplateSpec {
-	d.Spec.JobTemplate.ObjectMeta.Namespace = d.ObjectMeta.Namespace
-	return d.Spec.JobTemplate.Spec.Template
+	t := d.Spec.JobTemplate.Spec.Template
+	t.ObjectMeta.Namespace = d.ObjectMeta.Namespace
+	return t
 }

--- a/score/networkpolicy_test.go
+++ b/score/networkpolicy_test.go
@@ -2,6 +2,8 @@ package score
 
 import (
 	"testing"
+
+	"github.com/zegl/kube-score/scorecard"
 )
 
 func TestPodHasNoMatchingNetworkPolicy(t *testing.T) {
@@ -39,8 +41,38 @@ func TestNetworkPolicyTargetsPodNotMatching(t *testing.T) {
 	testExpectedScore(t, "networkpolicy-targets-pod-not-matching.yaml", "NetworkPolicy targets Pod", 1)
 }
 
-func TestNetworkPolicyNamespaceMatching(t *testing.T) {
+func TestNetworkPolicyDeploymentNamespaceMatching(t *testing.T) {
 	t.Parallel()
-	testExpectedScore(t, "networkpolicy-deployment-matching.yaml", "NetworkPolicy targets Pod", 10)
-	testExpectedScore(t, "networkpolicy-deployment-matching.yaml", "Pod NetworkPolicy", 10)
+	testExpectedScore(t, "networkpolicy-deployment-matching.yaml", "NetworkPolicy targets Pod", scorecard.GradeAllOK)
+	testExpectedScore(t, "networkpolicy-deployment-matching.yaml", "Pod NetworkPolicy", scorecard.GradeAllOK)
+}
+
+func TestNetworkPolicyStatefulSetNamespaceMatching(t *testing.T) {
+	t.Parallel()
+	testExpectedScore(t, "networkpolicy-statefulset-matching.yaml", "NetworkPolicy targets Pod", scorecard.GradeAllOK)
+	testExpectedScore(t, "networkpolicy-statefulset-matching.yaml", "Pod NetworkPolicy", scorecard.GradeAllOK)
+}
+
+func TestNetworkPolicyCronJobNamespaceMatching(t *testing.T) {
+	t.Parallel()
+	testExpectedScore(t, "networkpolicy-cronjob-matching.yaml", "NetworkPolicy targets Pod", scorecard.GradeAllOK)
+	testExpectedScore(t, "networkpolicy-cronjob-matching.yaml", "Pod NetworkPolicy", scorecard.GradeAllOK)
+}
+
+func TestNetworkPolicyDeploymentNamespaceNotMatchingSelector(t *testing.T) {
+	t.Parallel()
+	testExpectedScore(t, "networkpolicy-deployment-not-matching-selector.yaml", "NetworkPolicy targets Pod", scorecard.GradeCritical)
+	testExpectedScore(t, "networkpolicy-deployment-not-matching-selector.yaml", "Pod NetworkPolicy", scorecard.GradeCritical)
+}
+
+func TestNetworkPolicyStatefulSetNamespaceNotMatchingSelector(t *testing.T) {
+	t.Parallel()
+	testExpectedScore(t, "networkpolicy-statefulset-not-matching-selector.yaml", "NetworkPolicy targets Pod", scorecard.GradeCritical)
+	testExpectedScore(t, "networkpolicy-statefulset-not-matching-selector.yaml", "Pod NetworkPolicy", scorecard.GradeCritical)
+}
+
+func TestNetworkPolicyCronJobNamespaceNotMatchingSelector(t *testing.T) {
+	t.Parallel()
+	testExpectedScore(t, "networkpolicy-cronjob-not-matching-selector.yaml", "NetworkPolicy targets Pod", scorecard.GradeCritical)
+	testExpectedScore(t, "networkpolicy-cronjob-not-matching-selector.yaml", "Pod NetworkPolicy", scorecard.GradeCritical)
 }

--- a/score/testdata/networkpolicy-cronjob-matching.yaml
+++ b/score/testdata/networkpolicy-cronjob-matching.yaml
@@ -11,17 +11,19 @@ spec:
     - Egress
     - Ingress
 ---
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: batch/v1beta1
+kind: CronJob
 metadata:
-  name: deployment-test-1
+  name: cronjob-test-1
   namespace: testspace
 spec:
-  template:
-    metadata:
-      labels:
-        app: foo
+  jobTemplate:
     spec:
-      containers:
-        - name: foobar
-          image: foo:bar
+      template:
+        metadata:
+          labels:
+            app: foo
+        spec:
+          containers:
+          - name: foobar
+            image: foo:bar

--- a/score/testdata/networkpolicy-cronjob-not-matching-selector.yaml
+++ b/score/testdata/networkpolicy-cronjob-not-matching-selector.yaml
@@ -11,17 +11,19 @@ spec:
     - Egress
     - Ingress
 ---
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: batch/v1beta1
+kind: CronJob
 metadata:
-  name: deployment-test-1
+  name: cronjob-test-1
   namespace: testspace
 spec:
-  template:
-    metadata:
-      labels:
-        app: foo
+  jobTemplate:
     spec:
-      containers:
-        - name: foobar
-          image: foo:bar
+      template:
+        metadata:
+          labels:
+            app: not-foo
+        spec:
+          containers:
+          - name: foobar
+            image: foo:bar

--- a/score/testdata/networkpolicy-deployment-not-matching-selector.yaml
+++ b/score/testdata/networkpolicy-deployment-not-matching-selector.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       labels:
-        app: foo
+        app: not-foo
     spec:
       containers:
         - name: foobar

--- a/score/testdata/networkpolicy-statefulset-matching.yaml
+++ b/score/testdata/networkpolicy-statefulset-matching.yaml
@@ -12,9 +12,9 @@ spec:
     - Ingress
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
-  name: deployment-test-1
+  name: statefulset-test-1
   namespace: testspace
 spec:
   template:

--- a/score/testdata/networkpolicy-statefulset-not-matching-selector.yaml
+++ b/score/testdata/networkpolicy-statefulset-not-matching-selector.yaml
@@ -12,15 +12,15 @@ spec:
     - Ingress
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
-  name: deployment-test-1
+  name: statefulset-test-1
   namespace: testspace
 spec:
   template:
     metadata:
       labels:
-        app: foo
+        app: not-foo
     spec:
       containers:
         - name: foobar


### PR DESCRIPTION
```
RELNOTE: Fix for CronJob parsing - This fixes issues with namespace matching of CronJob resources, for CronJobs this mostly mean that the "Pod has NetworkPolicy" test was not working.
```