### PR TITLE
Security privileged defaults false

### DIFF
--- a/score/security/security.go
+++ b/score/security/security.go
@@ -52,7 +52,7 @@ func containerSecurityContext(podTemplate corev1.PodTemplateSpec, typeMeta metav
 
 		if sec.Privileged != nil && *sec.Privileged {
 			hasPrivileged = true
-			score.AddComment(container.Name, "The container is privileged", "Set securityContext.privileged to false")
+			score.AddComment(container.Name, "The container is privileged", "Set securityContext.privileged to false. Privileged containers can access all devices on the host, and grants almost the same access as non-containerized processes on the host.")
 		}
 
 		if sec.ReadOnlyRootFilesystem == nil || *sec.ReadOnlyRootFilesystem == false {

--- a/score/security/security.go
+++ b/score/security/security.go
@@ -50,7 +50,7 @@ func containerSecurityContext(podTemplate corev1.PodTemplateSpec, typeMeta metav
 			}
 		}
 
-		if sec.Privileged == nil || *sec.Privileged {
+		if sec.Privileged != nil && *sec.Privileged {
 			hasPrivileged = true
 			score.AddComment(container.Name, "The container is privileged", "Set securityContext.privileged to false")
 		}

--- a/score/security_test.go
+++ b/score/security_test.go
@@ -71,17 +71,7 @@ func TestPodSecurityContext(test *testing.T) {
 			},
 		},
 
-		// Context is non nul, but has all null values
-		{
-			ctx:           &corev1.SecurityContext{},
-			expectedGrade: 1,
-			expectedComment: &scorecard.TestScoreComment{
-				Path:        "foobar",
-				Summary:     "The container is privileged",
-				Description: "Set securityContext.privileged to false",
-			},
-		},
-		// Context is non nul, but has all null values
+		// Context is non-null, but has all null values
 		{
 			ctx:           &corev1.SecurityContext{},
 			expectedGrade: 1,
@@ -143,6 +133,52 @@ func TestPodSecurityContext(test *testing.T) {
 				Path:        "foobar",
 				Summary:     "The container running with a low group ID",
 				Description: "A groupid above 10 000 is recommended to avoid conflicts with the host. Set securityContext.runAsGroup to a value > 10000",
+			},
+		},
+
+		// Privileged defaults to "false"
+		{
+			ctx: &corev1.SecurityContext{
+				ReadOnlyRootFilesystem: b(true),
+				RunAsNonRoot:           b(true),
+			},
+			podCtx: &corev1.PodSecurityContext{
+				RunAsUser:  i(20000),
+				RunAsGroup: i(20000),
+			},
+			expectedGrade: scorecard.GradeAllOK,
+		},
+
+		// Privileged explicitly set to "false"
+		{
+			ctx: &corev1.SecurityContext{
+				ReadOnlyRootFilesystem: b(true),
+				RunAsNonRoot:           b(true),
+				Privileged:             b(false),
+			},
+			podCtx: &corev1.PodSecurityContext{
+				RunAsUser:  i(20000),
+				RunAsGroup: i(20000),
+			},
+			expectedGrade: scorecard.GradeAllOK,
+		},
+
+		// Privileged explicitly set to "true"
+		{
+			ctx: &corev1.SecurityContext{
+				ReadOnlyRootFilesystem: b(true),
+				RunAsNonRoot:           b(true),
+				Privileged:             b(true),
+			},
+			podCtx: &corev1.PodSecurityContext{
+				RunAsUser:  i(20000),
+				RunAsGroup: i(20000),
+			},
+			expectedGrade: scorecard.GradeCritical,
+			expectedComment: &scorecard.TestScoreComment{
+				Path:        "foobar",
+				Summary:     "The container is privileged",
+				Description: "Set securityContext.privileged to false",
 			},
 		},
 	}

--- a/score/security_test.go
+++ b/score/security_test.go
@@ -178,7 +178,7 @@ func TestPodSecurityContext(test *testing.T) {
 			expectedComment: &scorecard.TestScoreComment{
 				Path:        "foobar",
 				Summary:     "The container is privileged",
-				Description: "Set securityContext.privileged to false",
+				Description: "Set securityContext.privileged to false. Privileged containers can access all devices on the host, and grants almost the same access as non-containerized processes on the host.",
 			},
 		},
 	}


### PR DESCRIPTION
```
RELNOTE: correctly treat null securityContext.privileged as "false"
```

This fixes #275 