### PR TITLE
docker: create image for kustomize 3.8.1

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,6 +41,15 @@ dockers:
   - "zegl/kube-score:latest-helm"
   dockerfile: cmd/kube-score/helm.Dockerfile
 
+- goos: linux
+  goarch: amd64
+  binaries:
+  - kube-score
+  image_templates:
+  - "zegl/kube-score:{{ .Tag }}-kustomize"
+  - "zegl/kube-score:latest-kustomize"
+  dockerfile: cmd/kube-score/kustomize.Dockerfile
+
 checksum:
   name_template: 'checksums.txt'
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ The input to `kube-score` should be all applications that you deploy to the same
 helm template my-app | kube-score score -
 ```
 
+### Example with Kustomize
+
+```bash
+kustomize build . | kube-score score -
+```
+
 ### Example with static YAMLs
 
 ```bash

--- a/cmd/kube-score/kustomize.Dockerfile
+++ b/cmd/kube-score/kustomize.Dockerfile
@@ -1,0 +1,18 @@
+FROM debian:stretch as downloader
+
+ARG KUSTOMIZE_VERSION=v3.8.1
+ARG KUSTOMIZE_SHA256SUM="9d5b68f881ba89146678a0399469db24670cba4813e0299b47cb39a240006f37"
+
+RUN apt-get update && \
+    apt-get install -y curl && \
+    curl --location "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" > kustomize.tar.gz && \
+    echo "${KUSTOMIZE_SHA256SUM}  kustomize.tar.gz" | sha256sum --check && \
+    tar xzvf kustomize.tar.gz && \
+    chmod +x kustomize
+
+FROM alpine:3.10.1
+RUN apk update && \
+    apk upgrade && \
+    apk add bash ca-certificates git
+COPY --from=downloader kustomize /usr/bin/kustomize
+COPY kube-score /usr/bin/kube-score


### PR DESCRIPTION
<!--
    Optional: Add this change to the release notes by adding a RELNOTE comment
    If this shouldn't appear in the notes, simply remove this.
-->

```
RELNOTE: create a new docker image for kustomize (version v3.8.1)
```

Just one difference between helm and kustomize image, on kustomize I also added git dependency because for remote bases it is necessary.

closes #273 