### PR TITLE
score/apps: Deployment targeted by HPA does not have replicas configured

### DIFF
--- a/README_CHECKS.md
+++ b/README_CHECKS.md
@@ -21,5 +21,6 @@
 | stable-version | all | Checks if the object is using a deprecated apiVersion | default |
 | deployment-has-host-podantiaffinity | Deployment | Makes sure that a podAntiAffinity has been set that prevents multiple pods from being scheduled on the same node. https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ | default |
 | statefulset-has-host-podantiaffinity | StatefulSet | Makes sure that a podAntiAffinity has been set that prevents multiple pods from being scheduled on the same node. https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ | default |
+| deployment-targeted-by-hpa-does-not-have-replicas-configured | Deployment | Hakes sure that Deployments using a HorizontalPodAutoscaler doesn't have a statically configured replica count set | default |
 | label-values | all | Validates label values | default |
 | horizontalpodautoscaler-has-target | HorizontalPodAutoscaler | Makes sure that the HPA targets a valid object | default |

--- a/score/apps_test.go
+++ b/score/apps_test.go
@@ -62,3 +62,13 @@ func TestStatefulSetHasPodAntiAffinityUndefinedReplicas(t *testing.T) {
 	t.Parallel()
 	testExpectedScore(t, "statefulset-host-antiaffinity-undefined-replicas.yaml", "StatefulSet has host PodAntiAffinity", scorecard.GradeWarning)
 }
+
+func TestDeploymentWithHPAHasReplicas(t *testing.T) {
+	t.Parallel()
+	testExpectedScore(t, "deployment-with-hpa-has-replicas.yaml", "Deployment targeted by HPA does not have replicas configured", scorecard.GradeCritical)
+}
+
+func TestDeploymentWithHPANotHasReplicas(t *testing.T) {
+	t.Parallel()
+	testExpectedScore(t, "deployment-with-hpa-not-has-replicas.yaml", "Deployment targeted by HPA does not have replicas configured", scorecard.GradeAllOK)
+}

--- a/score/score.go
+++ b/score/score.go
@@ -34,7 +34,7 @@ func RegisterAllChecks(allObjects ks.AllTypes, cnf config.Configuration) *checks
 	security.Register(allChecks)
 	service.Register(allChecks, allObjects, allObjects)
 	stable.Register(allChecks)
-	apps.Register(allChecks)
+	apps.Register(allChecks, allObjects.HorizontalPodAutoscalers())
 	meta.Register(allChecks)
 	hpa.Register(allChecks, allObjects.Metas())
 

--- a/score/testdata/deployment-with-hpa-has-replicas.yaml
+++ b/score/testdata/deployment-with-hpa-has-replicas.yaml
@@ -1,0 +1,32 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: php-apache
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: php-apache
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: php-apache
+  namespace: default
+spec:
+  replicas: 123
+  template:
+    spec:
+      containers:
+        - name: foo
+          image: foo:latest

--- a/score/testdata/deployment-with-hpa-not-has-replicas.yaml
+++ b/score/testdata/deployment-with-hpa-not-has-replicas.yaml
@@ -1,0 +1,31 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: php-apache
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: php-apache
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: php-apache
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+        - name: foo
+          image: foo:latest


### PR DESCRIPTION
```
RELNOTE: New score "Deployment targeted by HPA does not have replicas configured"
```

This closes #286 
