### PR TITLE
score/stable: recommend Ingress networking.k8s.io/v1beta1

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"strconv"
 	"strings"
@@ -64,4 +65,8 @@ func (s Semver) LessThan(other Semver) bool {
 		return true
 	}
 	return false
+}
+
+func (s Semver) String() string {
+	return fmt.Sprintf("v%d.%d", s.Major, s.Minor)
 }

--- a/score/stable/stable_version.go
+++ b/score/stable/stable_version.go
@@ -25,6 +25,7 @@ func metaStableAvailable(kubernetsVersion config.Semver) func(meta domain.BothMe
 			"extensions/v1beta1": {
 				"Deployment": recommendedApi{"apps/v1", config.Semver{1, 9}},
 				"DaemonSet":  recommendedApi{"apps/v1", config.Semver{1, 9}},
+				"Ingress":    recommendedApi{"networking.k8s.io/v1beta1", config.Semver{1, 14}},
 			},
 			"apps/v1beta1": {
 				"Deployment":  recommendedApi{"apps/v1", config.Semver{1, 9}},
@@ -51,7 +52,7 @@ func metaStableAvailable(kubernetsVersion config.Semver) func(meta domain.BothMe
 				score.Grade = scorecard.GradeWarning
 				score.AddComment("",
 					fmt.Sprintf("The apiVersion and kind %s/%s is deprecated", meta.TypeMeta.APIVersion, meta.TypeMeta.Kind),
-					fmt.Sprintf("It's recommended to use %s instead", recAPI.newAPI),
+					fmt.Sprintf("It's recommended to use %s instead which has been available since Kubernetes %s", recAPI.newAPI, recAPI.availableSince.String()),
 				)
 				return
 			}

--- a/score/stable/stable_version_test.go
+++ b/score/stable/stable_version_test.go
@@ -21,5 +21,12 @@ func TestStableVersionNewKubernetesVersion(t *testing.T) {
 	newKubernetes := metaStableAvailable(config.Semver{1, 18})
 	scoreNew := newKubernetes(ks.BothMeta{TypeMeta: v1.TypeMeta{Kind: "Deployment", APIVersion: "extensions/v1beta1"}})
 	assert.Equal(t, scorecard.GradeWarning, scoreNew.Grade)
-	assert.Equal(t, []scorecard.TestScoreComment{{Path: "", Summary: "The apiVersion and kind extensions/v1beta1/Deployment is deprecated", Description: "It's recommended to use apps/v1 instead", DocumentationURL: ""}}, scoreNew.Comments)
+	assert.Equal(t, []scorecard.TestScoreComment{{Path: "", Summary: "The apiVersion and kind extensions/v1beta1/Deployment is deprecated", Description: "It's recommended to use apps/v1 instead which has been available since Kubernetes v1.9", DocumentationURL: ""}}, scoreNew.Comments)
+}
+
+func TestStableVersionIngress(t *testing.T) {
+	newKubernetes := metaStableAvailable(config.Semver{1, 18})
+	scoreNew := newKubernetes(ks.BothMeta{TypeMeta: v1.TypeMeta{Kind: "Ingress", APIVersion: "extensions/v1beta1"}})
+	assert.Equal(t, scorecard.GradeWarning, scoreNew.Grade)
+	assert.Equal(t, []scorecard.TestScoreComment{{Path: "", Summary: "The apiVersion and kind extensions/v1beta1/Ingress is deprecated", Description: "It's recommended to use networking.k8s.io/v1beta1 instead which has been available since Kubernetes v1.14", DocumentationURL: ""}}, scoreNew.Comments)
 }


### PR DESCRIPTION
```
RELNOTE: If using Kubernetes v1.14 or later, recommend to use the networking.k8s.io/v1beta1 Ingress API instead of extensions/v1beta1
```
