### PR TITLE
score/networkpolicy: handle empty podSelector properly in the pod-has-networkpolicy test

### DIFF
--- a/score/networkpolicy/networkpolicy.go
+++ b/score/networkpolicy/networkpolicy.go
@@ -30,10 +30,8 @@ func podHasNetworkPolicy(allNetpols []networkingv1.NetworkPolicy) func(spec core
 				continue
 			}
 
-			matchLabels := netPol.Spec.PodSelector.MatchLabels
-
-			for labelKey, labelVal := range matchLabels {
-				if podLabelVal, ok := podSpec.Labels[labelKey]; ok && podLabelVal == labelVal {
+			if selector, err := metav1.LabelSelectorAsSelector(&netPol.Spec.PodSelector); err == nil {
+				if selector.Matches(internal.MapLables(podSpec.Labels)) {
 
 					// Documentation of PolicyTypes
 					//

--- a/score/networkpolicy_test.go
+++ b/score/networkpolicy_test.go
@@ -76,3 +76,9 @@ func TestNetworkPolicyCronJobNamespaceNotMatchingSelector(t *testing.T) {
 	testExpectedScore(t, "networkpolicy-cronjob-not-matching-selector.yaml", "NetworkPolicy targets Pod", scorecard.GradeCritical)
 	testExpectedScore(t, "networkpolicy-cronjob-not-matching-selector.yaml", "Pod NetworkPolicy", scorecard.GradeCritical)
 }
+
+func TestNetworkPolicyEmptyPodSelector(t *testing.T) {
+	t.Parallel()
+	testExpectedScore(t, "networkpolicy-targets-all-pods.yaml", "NetworkPolicy targets Pod", scorecard.GradeAllOK)
+	testExpectedScore(t, "networkpolicy-targets-all-pods.yaml", "Pod NetworkPolicy", scorecard.GradeAllOK)
+}

--- a/score/testdata/networkpolicy-targets-all-pods.yaml
+++ b/score/testdata/networkpolicy-targets-all-pods.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: testapp-netpol
+  namespace: testspace
+spec:
+  podSelector: {}
+  ingress:
+    - {}
+  egress:
+    - {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-test-1
+  namespace: testspace
+  labels:
+    app: testapp
+spec:
+  containers:
+  - name: foobar
+    image: foo/bar:latest


### PR DESCRIPTION
This is done by adopting the Kubernetes-provided metav1.LabelSelector, as is already used by the networkpolicy-targets-pod test.

```
RELNOTE: Support empty podSelectors in the "Pod has NetworkPolicy" test
```

This fixes #293 