### PR TITLE
SARIF output format

### DIFF
--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -39,3 +39,37 @@ func TestParse(t *testing.T) {
 		}
 	}
 }
+
+func TestFileLocationHelm(t *testing.T) {
+	doc := `# Source: app1/templates/deployment.yaml
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: foo
+spec:
+  template:
+    metadata:
+      labels:
+        foo: bar`
+
+	fl := detectFileLocation("someName", 1, []byte(doc))
+	assert.Equal(t, "app1/templates/deployment.yaml", fl.Name)
+	assert.Equal(t, 1, fl.Line)
+}
+
+
+func TestFileLocation(t *testing.T) {
+	doc := `kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: foo
+spec:
+  template:
+    metadata:
+      labels:
+        foo: bar`
+
+	fl := detectFileLocation("someName", 123, []byte(doc))
+	assert.Equal(t, "someName", fl.Name)
+	assert.Equal(t, 123, fl.Line)
+}

--- a/renderer/sarif/sarif.go
+++ b/renderer/sarif/sarif.go
@@ -1,0 +1,96 @@
+package sarif
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+
+	"github.com/zegl/kube-score/domain"
+	"github.com/zegl/kube-score/sarif"
+	"github.com/zegl/kube-score/scorecard"
+)
+
+func Output(input *scorecard.Scorecard) io.Reader {
+	var results []sarif.Results
+	var rules []sarif.Rules
+
+	addRule := func(check domain.Check) {
+		for _, r := range rules {
+			if r.ID == check.ID {
+				return
+			}
+		}
+
+		rules = append(rules, sarif.Rules{
+			ID:   check.ID,
+			Name: check.Name,
+		})
+	}
+
+	for _, v := range *input {
+		for _, check := range v.Checks {
+			if check.Skipped {
+				continue
+			}
+
+			var level string
+			switch check.Grade {
+			case scorecard.GradeCritical:
+				level = "error"
+			case scorecard.GradeWarning:
+				level = "warning"
+			default:
+				continue
+			}
+
+			addRule(check.Check)
+
+			for _, comment := range check.Comments {
+				results = append(results, sarif.Results{
+					Message: sarif.Message{
+						Text: comment.Summary,
+					},
+					RuleID: check.Check.ID,
+					Level:  level,
+					Properties: sarif.ResultsProperties{
+						IssueConfidence: "HIGH",
+						IssueSeverity:   "HIGH",
+					},
+					Locations: []sarif.Locations{
+						{
+							PhysicalLocation: sarif.PhysicalLocation{
+								ArtifactLocation: sarif.ArtifactLocation{
+									URI: "file://" + v.FileLocation.Name,
+								},
+								ContextRegion: sarif.ContextRegion{
+									StartLine: v.FileLocation.Line,
+								},
+							},
+						},
+					},
+				})
+			}
+		}
+	}
+
+	run := sarif.Run{
+		Tool: sarif.Tool{
+			Driver: sarif.Driver{
+				Name:  "kube-score",
+				Rules: rules,
+			},
+		},
+		Results: results,
+	}
+	res := sarif.Sarif{
+		Runs:    []sarif.Run{run},
+		Version: "2.1.0",
+		Schema:  "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+	}
+
+	j, err := json.MarshalIndent(res, "", "    ")
+	if err != nil {
+		panic(err)
+	}
+	return bytes.NewBuffer(j)
+}

--- a/sarif/sarif.go
+++ b/sarif/sarif.go
@@ -1,0 +1,107 @@
+package sarif
+
+import (
+	"time"
+)
+
+type Sarif struct {
+	Runs    []Run  `json:"runs,omitempty"`
+	Version string `json:"version,omitempty"`
+	Schema  string `json:"$schema,omitempty"`
+}
+
+type Rules struct {
+	ID      string `json:"id,omitempty"`
+	Name    string `json:"name,omitempty"`
+	HelpURI string `json:"helpUri,omitempty"`
+}
+
+type Driver struct {
+	Name  string  `json:"name,omitempty"`
+	Rules []Rules `json:"rules,omitempty"`
+}
+
+type Tool struct {
+	Driver Driver `json:"driver,omitempty"`
+}
+
+type WorkingDirectory struct {
+	URI string `json:"uri,omitempty"`
+}
+
+type Invocation struct {
+	Arguments           []string         `json:"arguments,omitempty"`
+	ExecutionSuccessful bool             `json:"executionSuccessful,omitempty"`
+	CommandLine         string           `json:"commandLine,omitempty"`
+	EndTimeUtc          time.Time        `json:"endTimeUtc,omitempty"`
+	WorkingDirectory    WorkingDirectory `json:"workingDirectory,omitempty"`
+}
+
+type Conversion struct {
+	Tool       Tool       `json:"tool,omitempty"`
+	Invocation Invocation `json:"invocation,omitempty"`
+}
+
+type Invocations struct {
+	ExecutionSuccessful bool             `json:"executionSuccessful,omitempty"`
+	EndTimeUtc          time.Time        `json:"endTimeUtc,omitempty"`
+	WorkingDirectory    WorkingDirectory `json:"workingDirectory,omitempty"`
+}
+
+type Properties struct {
+}
+
+type Message struct {
+	Text string `json:"text,omitempty"`
+}
+
+type Snippet struct {
+	Text string `json:"text,omitempty"`
+}
+
+type Region struct {
+	Snippet   Snippet `json:"snippet,omitempty"`
+	StartLine int     `json:"startLine,omitempty"`
+}
+
+type ArtifactLocation struct {
+	URI string `json:"uri,omitempty"`
+}
+
+type ContextRegion struct {
+	Snippet   Snippet `json:"snippet,omitempty"`
+	EndLine   int     `json:"endLine,omitempty"`
+	StartLine int     `json:"startLine,omitempty"`
+}
+
+type PhysicalLocation struct {
+	Region           Region           `json:"region,omitempty"`
+	ArtifactLocation ArtifactLocation `json:"artifactLocation,omitempty"`
+	ContextRegion    ContextRegion    `json:"contextRegion,omitempty"`
+}
+
+type Locations struct {
+	PhysicalLocation PhysicalLocation `json:"physicalLocation,omitempty"`
+}
+
+type ResultsProperties struct {
+	IssueConfidence string `json:"issue_confidence,omitempty"`
+	IssueSeverity   string `json:"issue_severity,omitempty"`
+}
+
+type Results struct {
+	Message    Message           `json:"message,omitempty"`
+	Level      string            `json:"level,omitempty"`
+	Locations  []Locations       `json:"locations,omitempty"`
+	Properties ResultsProperties `json:"properties,omitempty"`
+	RuleID     string            `json:"ruleId,omitempty"`
+	RuleIndex  int               `json:"ruleIndex,omitempty"`
+}
+
+type Run struct {
+	Tool        Tool          `json:"tool,omitempty"`
+	Conversion  Conversion    `json:"conversion,omitempty"`
+	Invocations []Invocations `json:"invocations,omitempty"`
+	Properties  Properties    `json:"properties,omitempty"`
+	Results     []Results     `json:"results,omitempty"`
+}

--- a/score/filelocation_test.go
+++ b/score/filelocation_test.go
@@ -1,0 +1,36 @@
+package score
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+
+	"github.com/zegl/kube-score/config"
+	ks "github.com/zegl/kube-score/domain"
+)
+
+func TestFileLocationHelm(t *testing.T) {
+	sc, err := testScore(config.Configuration{
+		AllFiles:          []ks.NamedReader{testFile("linenumbers-helm.yaml")},
+		KubernetesVersion: config.Semver{1, 18},
+	})
+	assert.Nil(t, err)
+	for _, c := range sc {
+		assert.Equal(t, "app1/templates/deployment.yaml", c.FileLocation.Name)
+	}
+	assert.Equal(t, 1, sc["Deployment/apps/v1//foo"].FileLocation.Line)
+	assert.Equal(t, 1, sc["Deployment/apps/v1//foo2"].FileLocation.Line)
+}
+
+
+func TestFileLocation(t *testing.T) {
+	sc, err := testScore(config.Configuration{
+		AllFiles:          []ks.NamedReader{testFile("linenumbers.yaml")},
+		KubernetesVersion: config.Semver{1, 18},
+	})
+	assert.Nil(t, err)
+	for _, c := range sc {
+		assert.Equal(t, "testdata/linenumbers.yaml", c.FileLocation.Name)
+	}
+	assert.Equal(t, 2, sc["Deployment/apps/v1//foo"].FileLocation.Line)
+	assert.Equal(t, 12, sc["Deployment/apps/v1//foo2"].FileLocation.Line)
+}

--- a/score/testdata/helm/app1/Chart.yaml
+++ b/score/testdata/helm/app1/Chart.yaml
@@ -1,0 +1,2 @@
+name: app1
+version: v1.0.0

--- a/score/testdata/helm/app1/templates/deployment.yaml
+++ b/score/testdata/helm/app1/templates/deployment.yaml
@@ -1,0 +1,19 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: foo
+spec:
+  template:
+    metadata:
+      labels:
+        foo: bar
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: foo2
+spec:
+  template:
+    metadata:
+      labels:
+        foo: bar2

--- a/score/testdata/linenumbers-helm.yaml
+++ b/score/testdata/linenumbers-helm.yaml
@@ -1,0 +1,22 @@
+---
+# Source: app1/templates/deployment.yaml
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: foo
+spec:
+  template:
+    metadata:
+      labels:
+        foo: bar
+---
+# Source: app1/templates/deployment.yaml
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: foo2
+spec:
+  template:
+    metadata:
+      labels:
+        foo: bar2

--- a/score/testdata/linenumbers.yaml
+++ b/score/testdata/linenumbers.yaml
@@ -1,0 +1,20 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: foo
+spec:
+  template:
+    metadata:
+      labels:
+        foo: bar
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: foo2
+spec:
+  template:
+    metadata:
+      labels:
+        foo: bar2


### PR DESCRIPTION
```
RELNOTE: Add support for the [SARIF](https://sarifweb.azurewebsites.net/) output format (`--output-format sarif`). This API is considered to be in Alpha.
```

The support is fairly basic, but it works!

Here's a screenshot of the SARIF Viewer in VS Code, using a SARIF-file generated from some of kube-scores testdata:

```bash
kube-score score -o sarif \
    score/testdata/deployment-host-antiaffinity-preffered-selector-expression.yaml \
    score/testdata/deployment-poddisruptionbudget-expression-matches.yaml > output.sarif
```

<img width="1742" alt="Screen Shot 2020-08-22 at 21 07 48 " src="https://user-images.githubusercontent.com/47952/90963834-8e8f6180-e4bb-11ea-8a70-d52c697e500d.png">
