### PR TITLE
score/apps: StatefulSets should have a valid headless serviceName 

### DIFF
--- a/README_CHECKS.md
+++ b/README_CHECKS.md
@@ -22,5 +22,6 @@
 | deployment-has-host-podantiaffinity | Deployment | Makes sure that a podAntiAffinity has been set that prevents multiple pods from being scheduled on the same node. https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ | default |
 | statefulset-has-host-podantiaffinity | StatefulSet | Makes sure that a podAntiAffinity has been set that prevents multiple pods from being scheduled on the same node. https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ | default |
 | deployment-targeted-by-hpa-does-not-have-replicas-configured | Deployment | Makes sure that Deployments using a HorizontalPodAutoscaler doesn't have a statically configured replica count set | default |
+| statefulset-has-servicename | StatefulSet | Makes sure that StatefulSets have a existing serviceName that is headless. | default |
 | label-values | all | Validates label values | default |
 | horizontalpodautoscaler-has-target | HorizontalPodAutoscaler | Makes sure that the HPA targets a valid object | default |

--- a/score/apps_test.go
+++ b/score/apps_test.go
@@ -72,3 +72,28 @@ func TestDeploymentWithHPANotHasReplicas(t *testing.T) {
 	t.Parallel()
 	testExpectedScore(t, "deployment-with-hpa-not-has-replicas.yaml", "Deployment targeted by HPA does not have replicas configured", scorecard.GradeAllOK)
 }
+
+func TestStatefulsetHasServiceName(t *testing.T) {
+	t.Parallel()
+	testExpectedScore(t, "statefulset-service-name.yaml", "StatefulSet has ServiceName", scorecard.GradeAllOK)
+}
+
+func TestStatefulsetHasServiceNameDifferentName(t *testing.T) {
+	t.Parallel()
+	testExpectedScore(t, "statefulset-service-name-different-name.yaml", "StatefulSet has ServiceName", scorecard.GradeCritical)
+}
+
+func TestStatefulsetHasServiceNameDifferentNamespace(t *testing.T) {
+	t.Parallel()
+	testExpectedScore(t, "statefulset-service-name-not-headless.yaml", "StatefulSet has ServiceName", scorecard.GradeCritical)
+}
+
+func TestStatefulsetHasServiceNameDifferentLabel(t *testing.T) {
+	t.Parallel()
+	testExpectedScore(t, "statefulset-service-name-different-label.yaml", "StatefulSet has ServiceName", scorecard.GradeCritical)
+}
+
+func TestStatefulsetHasServiceNameNotHeadless(t *testing.T) {
+	t.Parallel()
+	testExpectedScore(t, "statefulset-service-name-not-headless.yaml", "StatefulSet has ServiceName", scorecard.GradeCritical)
+}

--- a/score/score.go
+++ b/score/score.go
@@ -34,7 +34,7 @@ func RegisterAllChecks(allObjects ks.AllTypes, cnf config.Configuration) *checks
 	security.Register(allChecks)
 	service.Register(allChecks, allObjects, allObjects)
 	stable.Register(cnf.KubernetesVersion, allChecks)
-	apps.Register(allChecks, allObjects.HorizontalPodAutoscalers())
+	apps.Register(allChecks, allObjects.HorizontalPodAutoscalers(), allObjects.Services())
 	meta.Register(allChecks)
 	hpa.Register(allChecks, allObjects.Metas())
 

--- a/score/testdata/statefulset-service-name-different-label.yaml
+++ b/score/testdata/statefulset-service-name-different-label.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-test-1
+spec:
+  clusterIP: "None"
+  selector:
+    app: foo
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: statefulset-test-1
+spec:
+  serviceName: svc-test-1
+  template:
+    metadata:
+      labels:
+        app: bar
+    spec:
+      containers:
+      - name: foobar
+        image: foo/bar:123

--- a/score/testdata/statefulset-service-name-different-name.yaml
+++ b/score/testdata/statefulset-service-name-different-name.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-test-2
+spec:
+  clusterIP: "None"
+  selector:
+    app: foo
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: statefulset-test-1
+spec:
+  serviceName: svc-test-1
+  template:
+    metadata:
+      labels:
+        app: foo
+    spec:
+      containers:
+      - name: foobar
+        image: foo/bar:123

--- a/score/testdata/statefulset-service-name-different-namespace.yaml
+++ b/score/testdata/statefulset-service-name-different-namespace.yaml
@@ -1,0 +1,29 @@
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-test-1
+spec:
+  clusterIP: "None"
+  selector:
+    app: foo
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: statefulset-test-1
+  namespace: ns-test-1
+spec:
+  serviceName: svc-test-1
+  template:
+    metadata:
+      labels:
+        app: foo
+    spec:
+      containers:
+      - name: foobar
+        image: foo/bar:123

--- a/score/testdata/statefulset-service-name-not-headless.yaml
+++ b/score/testdata/statefulset-service-name-not-headless.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-test-1
+spec:
+  selector:
+    app: foo
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: statefulset-test-1
+spec:
+  serviceName: svc-test-1
+  template:
+    metadata:
+      labels:
+        app: foo
+    spec:
+      containers:
+      - name: foobar
+        image: foo/bar:123

--- a/score/testdata/statefulset-service-name.yaml
+++ b/score/testdata/statefulset-service-name.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-test-1
+spec:
+  clusterIP: "None"
+  selector:
+    app: foo
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: statefulset-test-1
+spec:
+  serviceName: svc-test-1
+  template:
+    metadata:
+      labels:
+        app: foo
+    spec:
+      containers:
+      - name: foobar
+        image: foo/bar:123


### PR DESCRIPTION
<!--
    Optional: Add this change to the release notes by adding a RELNOTE comment
    If this shouldn't appear in the notes, simply remove this.
-->

```
RELNOTE: Validate serviceName of a StatefulSet 
```

This PR closes #315 

This adds `statefulset-has-servicename` that checks following rules:
- StatefulSets `.spec.serviceName` matches a Service in the same namespace.
- The Service is a Headless Service.
    > StatefulSets currently require a Headless Service to be responsible for the network identity of the Pods. You are responsible for creating this Service.
https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#limitations
- The Service has a selector that matches the StatefulSet.