### PR TITLE
probes: correctly check if a pod is targeted by a service

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -309,6 +309,7 @@ k8s.io/apimachinery v0.18.8/go.mod h1:6sQd+iHEqmOtALqOFjSWp2KZ9F0wlU/nWm0ZgsYWMi
 k8s.io/apimachinery v0.19.0/go.mod h1:DnPGDnARWFvYa3pMHgSxtbZb7gpzzAZ1pTfaUNDVlmA=
 k8s.io/apimachinery v0.19.1 h1:cwsxZazM/LA9aUsBaL4bRS5ygoM6bYp8dFk22DSYQa4=
 k8s.io/apimachinery v0.19.1/go.mod h1:DnPGDnARWFvYa3pMHgSxtbZb7gpzzAZ1pTfaUNDVlmA=
+k8s.io/apimachinery v0.19.2 h1:5Gy9vQpAGTKHPVOh5c4plE274X8D/6cuEiTO2zve7tc=
 k8s.io/apimachinery v0.19.2/go.mod h1:DnPGDnARWFvYa3pMHgSxtbZb7gpzzAZ1pTfaUNDVlmA=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=

--- a/score/probe_test.go
+++ b/score/probe_test.go
@@ -1,8 +1,9 @@
 package score
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/zegl/kube-score/scorecard"
 )
@@ -56,6 +57,13 @@ func TestProbesTargetedByServiceSameNamespace(t *testing.T) {
 	assert.Equal(t, "Container is missing a readinessProbe", comments[0].Summary)
 }
 
+func TestProbesTargetedByServiceSameNamespaceMultiLabels(t *testing.T) {
+	t.Parallel()
+	comments := testExpectedScore(t, "pod-probes-targeted-by-service-same-namespace-multi-labels.yaml", "Pod Probes", scorecard.GradeCritical)
+	assert.Len(t, comments, 1)
+	assert.Equal(t, "Container is missing a readinessProbe", comments[0].Summary)
+}
+
 func TestProbesTargetedByServiceDifferentNamespace(t *testing.T) {
 	t.Parallel()
 	comments := testExpectedScore(t, "pod-probes-targeted-by-service-different-namespace.yaml", "Pod Probes", scorecard.GradeAllOK)
@@ -66,6 +74,13 @@ func TestProbesTargetedByServiceDifferentNamespace(t *testing.T) {
 func TestProbesTargetedByServiceNotTargeted(t *testing.T) {
 	t.Parallel()
 	comments := testExpectedScore(t, "pod-probes-not-targeted-by-service.yaml", "Pod Probes", scorecard.GradeAllOK)
+	assert.Len(t, comments, 1)
+	assert.Equal(t, "The pod is not targeted by a service, skipping probe checks.", comments[0].Summary)
+}
+
+func TestProbesTargetedByServiceNotTargetedMultiLabels(t *testing.T) {
+	t.Parallel()
+	comments := testExpectedScore(t, "pod-probes-not-targeted-by-service-multi-labels.yaml", "Pod Probes", scorecard.GradeAllOK)
 	assert.Len(t, comments, 1)
 	assert.Equal(t, "The pod is not targeted by a service, skipping probe checks.", comments[0].Summary)
 }

--- a/score/probes/probes_test.go
+++ b/score/probes/probes_test.go
@@ -1,0 +1,135 @@
+package probes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPodIsTargetedByService(t *testing.T) {
+	t.Run("single label match", func(t *testing.T) {
+		res := podIsTargetedByService(v1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"foo": "bar"},
+			},
+		},
+			v1.Service{
+				Spec: v1.ServiceSpec{
+					Selector: map[string]string{"foo": "bar"},
+				},
+			},
+		)
+
+		assert.True(t, res)
+	})
+
+	t.Run("single label mismatch", func(t *testing.T) {
+		res := podIsTargetedByService(v1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"foo": "bar"},
+			},
+		},
+			v1.Service{
+				Spec: v1.ServiceSpec{
+					Selector: map[string]string{"foo": "baz"},
+				},
+			},
+		)
+
+		assert.False(t, res)
+	})
+
+	t.Run("multi label match", func(t *testing.T) {
+		res := podIsTargetedByService(v1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"foo1": "bar1",
+					"foo2": "bar2",
+				},
+			},
+		},
+			v1.Service{
+				Spec: v1.ServiceSpec{
+					Selector: map[string]string{
+						"foo1": "bar1",
+						"foo2": "bar2",
+					},
+				},
+			},
+		)
+
+		assert.True(t, res)
+	})
+
+	t.Run("multi non full match", func(t *testing.T) {
+		res := podIsTargetedByService(v1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"foo1": "bar1",
+					"foo2": "bar2",
+				},
+			},
+		},
+			v1.Service{
+				Spec: v1.ServiceSpec{
+					Selector: map[string]string{
+						"foo1": "bar1",
+						"foo2": "bar-whatever",
+					},
+				},
+			},
+		)
+
+		assert.False(t, res)
+	})
+
+	t.Run("multi label match same namespace", func(t *testing.T) {
+		res := podIsTargetedByService(v1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foospace",
+				Labels: map[string]string{
+					"foo1": "bar1",
+					"foo2": "bar2",
+				},
+			},
+		},
+			v1.Service{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "foospace"},
+				Spec: v1.ServiceSpec{
+					Selector: map[string]string{
+						"foo1": "bar1",
+						"foo2": "bar2",
+					},
+				},
+			},
+		)
+
+		assert.True(t, res)
+	})
+
+	t.Run("multi label match different namespace", func(t *testing.T) {
+		res := podIsTargetedByService(v1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foospace",
+				Labels: map[string]string{
+					"foo1": "bar1",
+					"foo2": "bar2",
+				},
+			},
+		},
+			v1.Service{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "someOtherNamespace"},
+				Spec: v1.ServiceSpec{
+					Selector: map[string]string{
+						"foo1": "bar1",
+						"foo2": "bar2",
+					},
+				},
+			},
+		)
+
+		assert.False(t, res)
+	})
+}

--- a/score/testdata/pod-probes-not-targeted-by-service-multi-labels.yaml
+++ b/score/testdata/pod-probes-not-targeted-by-service-multi-labels.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-test-1
+  labels:
+    app: my-app
+    otherLabel: foo
+spec:
+  containers:
+  - name: foobar
+    image: foo/bar:latest
+    livenessProbe:
+      httpGet:
+        path: /ready
+        port: 8080
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: my-app-not-matching
+    otherLabel: foo
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080

--- a/score/testdata/pod-probes-targeted-by-service-same-namespace-multi-labels.yaml
+++ b/score/testdata/pod-probes-targeted-by-service-same-namespace-multi-labels.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-test-1
+  namespace: foospace
+  labels:
+    app: my-app
+    foo: bar
+spec:
+  containers:
+  - name: foobar
+    image: foo/bar:latest
+    livenessProbe:
+      httpGet:
+        path: /ready
+        port: 8080
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: my-service
+  namespace: foospace
+spec:
+  selector:
+    app: my-app
+    foo: bar
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080


### PR DESCRIPTION
Previously only one label needed to match and not all, causing false positives

```
RELNOTE: Fix a bug in the "Pod Probes" test where a Pod could incorrectly be considered to be targeted by a Service
```

This fixes #316