### PR TITLE
Add ability to disable test on specified namespaces

### DIFF
--- a/cmd/kube-score/main.go
+++ b/cmd/kube-score/main.go
@@ -105,7 +105,7 @@ func scoreFiles(binName string, args []string) error {
 	outputVersion := fs.String("output-version", "", "Changes the version of the --output-format. The 'json' format has version 'v2' (default) and 'v1' (deprecated, will be removed in v1.7.0). The 'human' and 'ci' formats has only version 'v1' (default). If not explicitly set, the default version for that particular output format will be used.")
 	optionalTests := fs.StringSlice("enable-optional-test", []string{}, "Enable an optional test, can be set multiple times")
 	ignoreTests := fs.StringSlice("ignore-test", []string{}, "Disable a test, can be set multiple times")
-        ignoreNamespaces := fs.StringSlice("ignore-namespace", []string{}, "Disable test on specific namespace, can be set multiple times")
+	ignoreNamespaces := fs.StringSlice("ignore-namespace", []string{}, "Disable test on specific namespace, can be set multiple times")
 	disableIgnoreChecksAnnotation := fs.Bool("disable-ignore-checks-annotations", false, "Set to true to disable the effect of the 'kube-score/ignore' annotations")
 	kubernetesVersion := fs.String("kubernetes-version", "v1.18", "Setting the kubernetes-version will affect the checks ran against the manifests. Set this to the version of Kubernetes that you're using in production for the best results.")
 	setDefault(fs, binName, "score", false)
@@ -155,7 +155,7 @@ Use "-" as filename to read from STDIN.`, execName(binName))
 	}
 
 	ignoredTests := listToStructMap(ignoreTests)
-        ignoredNamespaces := listToStructMap(ignoreNamespaces)
+	ignoredNamespaces := listToStructMap(ignoreNamespaces)
 	enabledOptionalTests := listToStructMap(optionalTests)
 
 	kubeVer, err := config.ParseSemver(*kubernetesVersion)

--- a/cmd/kube-score/main.go
+++ b/cmd/kube-score/main.go
@@ -105,6 +105,7 @@ func scoreFiles(binName string, args []string) error {
 	outputVersion := fs.String("output-version", "", "Changes the version of the --output-format. The 'json' format has version 'v2' (default) and 'v1' (deprecated, will be removed in v1.7.0). The 'human' and 'ci' formats has only version 'v1' (default). If not explicitly set, the default version for that particular output format will be used.")
 	optionalTests := fs.StringSlice("enable-optional-test", []string{}, "Enable an optional test, can be set multiple times")
 	ignoreTests := fs.StringSlice("ignore-test", []string{}, "Disable a test, can be set multiple times")
+        ignoreNamespaces := fs.StringSlice("ignore-namespace", []string{}, "Disable test on specific namespace, can be set multiple times")
 	disableIgnoreChecksAnnotation := fs.Bool("disable-ignore-checks-annotations", false, "Set to true to disable the effect of the 'kube-score/ignore' annotations")
 	kubernetesVersion := fs.String("kubernetes-version", "v1.18", "Setting the kubernetes-version will affect the checks ran against the manifests. Set this to the version of Kubernetes that you're using in production for the best results.")
 	setDefault(fs, binName, "score", false)
@@ -154,6 +155,7 @@ Use "-" as filename to read from STDIN.`, execName(binName))
 	}
 
 	ignoredTests := listToStructMap(ignoreTests)
+        ignoredNamespaces := listToStructMap(ignoreNamespaces)
 	enabledOptionalTests := listToStructMap(optionalTests)
 
 	kubeVer, err := config.ParseSemver(*kubernetesVersion)
@@ -166,6 +168,7 @@ Use "-" as filename to read from STDIN.`, execName(binName))
 		VerboseOutput:                         *verboseOutput,
 		IgnoreContainerCpuLimitRequirement:    *ignoreContainerCpuLimit,
 		IgnoreContainerMemoryLimitRequirement: *ignoreContainerMemoryLimit,
+		IgnoredNamespaces:                     ignoredNamespaces,
 		IgnoredTests:                          ignoredTests,
 		EnabledOptionalTests:                  enabledOptionalTests,
 		UseIgnoreChecksAnnotation:             !*disableIgnoreChecksAnnotation,

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ type Configuration struct {
 	VerboseOutput                         int
 	IgnoreContainerCpuLimitRequirement    bool
 	IgnoreContainerMemoryLimitRequirement bool
+	IgnoredNamespaces                     map[string]struct{}
 	IgnoredTests                          map[string]struct{}
 	EnabledOptionalTests                  map[string]struct{}
 	UseIgnoreChecksAnnotation             bool

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -122,6 +122,7 @@ func Empty() ks.AllTypes {
 
 func ParseFiles(cnf config.Configuration) (ks.AllTypes, error) {
 	s := &parsedObjects{}
+	s2 := &parsedObjects{}
 
 	for _, namedReader := range cnf.AllFiles {
 		fullFile, err := ioutil.ReadAll(namedReader)
@@ -153,7 +154,77 @@ func ParseFiles(cnf config.Configuration) (ks.AllTypes, error) {
 		}
 	}
 
-	return s, nil
+	for _,pod := range s.pods {
+		ns := pod.Pod().ObjectMeta.Namespace
+		if _, ok := cnf.IgnoredNamespaces[ns]; !ok {
+			s2.pods = append(s2.pods, pod)
+		}
+	}
+
+	for _,podspecer := range s.podspecers {
+		ns := podspecer.GetObjectMeta().Namespace
+		if _, ok := cnf.IgnoredNamespaces[ns]; !ok {
+			s2.podspecers = append(s2.podspecers, podspecer)
+		}
+	}
+
+	for _,netpool := range s.networkPolicies {
+		ns := netpool.NetworkPolicy().ObjectMeta.Namespace
+		if _, ok := cnf.IgnoredNamespaces[ns]; !ok {
+			s2.networkPolicies = append(s2.networkPolicies, netpool)
+		}
+	}
+
+	for _,service := range s.services {
+		ns := service.Service().ObjectMeta.Namespace
+		if _, ok := cnf.IgnoredNamespaces[ns]; !ok {
+			s2.services = append(s2.services, service)
+		}
+	}
+
+	for _,deployment := range s.deployments {
+		ns := deployment.Deployment().ObjectMeta.Namespace
+		if _, ok := cnf.IgnoredNamespaces[ns]; !ok {
+			s2.deployments = append(s2.deployments, deployment)
+		}
+	}
+
+	for _,statefulset := range s.statefulsets {
+		ns := statefulset.StatefulSet().ObjectMeta.Namespace
+		if _, ok := cnf.IgnoredNamespaces[ns]; !ok {
+			s2.statefulsets = append(s2.statefulsets, statefulset)
+		}
+	}
+
+	for _,ingress := range s.ingresses {
+		ns := ingress.GetObjectMeta().Namespace
+		if _, ok := cnf.IgnoredNamespaces[ns]; !ok {
+			s2.ingresses = append(s2.ingresses, ingress)
+		}
+	}
+
+	for _,cjob := range s.cronjobs {
+		ns := cjob.CronJob().ObjectMeta.Namespace
+		if _, ok := cnf.IgnoredNamespaces[ns]; !ok {
+			s2.cronjobs = append(s2.cronjobs, cjob)
+		}
+	}
+
+	for _,hpa := range s.hpaTargeters {
+		ns := hpa.GetObjectMeta().Namespace
+		if _, ok := cnf.IgnoredNamespaces[ns]; !ok {
+			s2.hpaTargeters = append(s2.hpaTargeters, hpa)
+		}
+	}
+
+	for _,pdb := range s.podDisruptionBudgets {
+		ns := pdb.PodDisruptionBudget().ObjectMeta.Namespace
+		if _, ok := cnf.IgnoredNamespaces[ns]; !ok {
+			s2.podDisruptionBudgets = append(s2.podDisruptionBudgets, pdb)
+		}
+	}
+
+	return s2, nil
 }
 
 func detectAndDecode(cnf config.Configuration, s *parsedObjects, fileName string, fileOffset int, raw []byte) error {

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -223,7 +223,13 @@ func ParseFiles(cnf config.Configuration) (ks.AllTypes, error) {
 			s2.podDisruptionBudgets = append(s2.podDisruptionBudgets, pdb)
 		}
 	}
-	s2.bothMetas = s.bothMetas
+
+	for _,bothMeta := range s.bothMetas {
+		ns := bothMeta.ObjectMeta.Namespace
+		if _, ok := cnf.IgnoredNamespaces[ns]; !ok {
+			s2.bothMetas = append(s2.bothMetas, bothMeta)
+		}
+	}
 
 	return s2, nil
 }

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -223,6 +223,7 @@ func ParseFiles(cnf config.Configuration) (ks.AllTypes, error) {
 			s2.podDisruptionBudgets = append(s2.podDisruptionBudgets, pdb)
 		}
 	}
+	s2.bothMetas = s.bothMetas
 
 	return s2, nil
 }

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -122,7 +122,6 @@ func Empty() ks.AllTypes {
 
 func ParseFiles(cnf config.Configuration) (ks.AllTypes, error) {
 	s := &parsedObjects{}
-	s2 := &parsedObjects{}
 
 	for _, namedReader := range cnf.AllFiles {
 		fullFile, err := ioutil.ReadAll(namedReader)
@@ -154,84 +153,7 @@ func ParseFiles(cnf config.Configuration) (ks.AllTypes, error) {
 		}
 	}
 
-	for _,pod := range s.pods {
-		ns := pod.Pod().ObjectMeta.Namespace
-		if _, ok := cnf.IgnoredNamespaces[ns]; !ok {
-			s2.pods = append(s2.pods, pod)
-		}
-	}
-
-	for _,podspecer := range s.podspecers {
-		ns := podspecer.GetObjectMeta().Namespace
-		if _, ok := cnf.IgnoredNamespaces[ns]; !ok {
-			s2.podspecers = append(s2.podspecers, podspecer)
-		}
-	}
-
-	for _,netpool := range s.networkPolicies {
-		ns := netpool.NetworkPolicy().ObjectMeta.Namespace
-		if _, ok := cnf.IgnoredNamespaces[ns]; !ok {
-			s2.networkPolicies = append(s2.networkPolicies, netpool)
-		}
-	}
-
-	for _,service := range s.services {
-		ns := service.Service().ObjectMeta.Namespace
-		if _, ok := cnf.IgnoredNamespaces[ns]; !ok {
-			s2.services = append(s2.services, service)
-		}
-	}
-
-	for _,deployment := range s.deployments {
-		ns := deployment.Deployment().ObjectMeta.Namespace
-		if _, ok := cnf.IgnoredNamespaces[ns]; !ok {
-			s2.deployments = append(s2.deployments, deployment)
-		}
-	}
-
-	for _,statefulset := range s.statefulsets {
-		ns := statefulset.StatefulSet().ObjectMeta.Namespace
-		if _, ok := cnf.IgnoredNamespaces[ns]; !ok {
-			s2.statefulsets = append(s2.statefulsets, statefulset)
-		}
-	}
-
-	for _,ingress := range s.ingresses {
-		ns := ingress.GetObjectMeta().Namespace
-		if _, ok := cnf.IgnoredNamespaces[ns]; !ok {
-			s2.ingresses = append(s2.ingresses, ingress)
-		}
-	}
-
-	for _,cjob := range s.cronjobs {
-		ns := cjob.CronJob().ObjectMeta.Namespace
-		if _, ok := cnf.IgnoredNamespaces[ns]; !ok {
-			s2.cronjobs = append(s2.cronjobs, cjob)
-		}
-	}
-
-	for _,hpa := range s.hpaTargeters {
-		ns := hpa.GetObjectMeta().Namespace
-		if _, ok := cnf.IgnoredNamespaces[ns]; !ok {
-			s2.hpaTargeters = append(s2.hpaTargeters, hpa)
-		}
-	}
-
-	for _,pdb := range s.podDisruptionBudgets {
-		ns := pdb.PodDisruptionBudget().ObjectMeta.Namespace
-		if _, ok := cnf.IgnoredNamespaces[ns]; !ok {
-			s2.podDisruptionBudgets = append(s2.podDisruptionBudgets, pdb)
-		}
-	}
-
-	for _,bothMeta := range s.bothMetas {
-		ns := bothMeta.ObjectMeta.Namespace
-		if _, ok := cnf.IgnoredNamespaces[ns]; !ok {
-			s2.bothMetas = append(s2.bothMetas, bothMeta)
-		}
-	}
-
-	return s2, nil
+	return s, nil
 }
 
 func detectAndDecode(cnf config.Configuration, s *parsedObjects, fileName string, fileOffset int, raw []byte) error {

--- a/score/score.go
+++ b/score/score.go
@@ -54,14 +54,14 @@ func Score(allObjects ks.AllTypes, cnf config.Configuration) (*scorecard.Scoreca
 	for _, ingress := range allObjects.Ingresses() {
 		o := newObject(ingress.GetTypeMeta(), ingress.GetObjectMeta())
 		for _, test := range allChecks.Ingresses() {
-			o.Add(test.Fn(ingress), test.Check, ingress)
+			o.Add(test.Fn(ingress), test.Check, ingress, cnf)
 		}
 	}
 
 	for _, meta := range allObjects.Metas() {
 		o := newObject(meta.TypeMeta, meta.ObjectMeta)
 		for _, test := range allChecks.Metas() {
-			o.Add(test.Fn(meta), test.Check, meta)
+			o.Add(test.Fn(meta), test.Check, meta, cnf)
 		}
 	}
 
@@ -72,7 +72,7 @@ func Score(allObjects ks.AllTypes, cnf config.Configuration) (*scorecard.Scoreca
 				ObjectMeta: pod.Pod().ObjectMeta,
 				Spec:       pod.Pod().Spec,
 			}, pod.Pod().TypeMeta)
-			o.Add(score, test.Check, pod)
+			o.Add(score, test.Check, pod, cnf)
 		}
 	}
 
@@ -80,14 +80,14 @@ func Score(allObjects ks.AllTypes, cnf config.Configuration) (*scorecard.Scoreca
 		o := newObject(podspecer.GetTypeMeta(), podspecer.GetObjectMeta())
 		for _, test := range allChecks.Pods() {
 			score := test.Fn(podspecer.GetPodTemplateSpec(), podspecer.GetTypeMeta())
-			o.Add(score, test.Check, podspecer)
+			o.Add(score, test.Check, podspecer, cnf)
 		}
 	}
 
 	for _, service := range allObjects.Services() {
 		o := newObject(service.Service().TypeMeta, service.Service().ObjectMeta)
 		for _, test := range allChecks.Services() {
-			o.Add(test.Fn(service.Service()), test.Check, service)
+			o.Add(test.Fn(service.Service()), test.Check, service, cnf)
 		}
 	}
 
@@ -98,7 +98,7 @@ func Score(allObjects ks.AllTypes, cnf config.Configuration) (*scorecard.Scoreca
 			if err != nil {
 				return nil, err
 			}
-			o.Add(res, test.Check, statefulset)
+			o.Add(res, test.Check, statefulset, cnf)
 		}
 	}
 
@@ -109,28 +109,28 @@ func Score(allObjects ks.AllTypes, cnf config.Configuration) (*scorecard.Scoreca
 			if err != nil {
 				return nil, err
 			}
-			o.Add(res, test.Check, deployment)
+			o.Add(res, test.Check, deployment, cnf)
 		}
 	}
 
 	for _, netpol := range allObjects.NetworkPolicies() {
 		o := newObject(netpol.NetworkPolicy().TypeMeta, netpol.NetworkPolicy().ObjectMeta)
 		for _, test := range allChecks.NetworkPolicies() {
-			o.Add(test.Fn(netpol.NetworkPolicy()), test.Check, netpol)
+			o.Add(test.Fn(netpol.NetworkPolicy()), test.Check, netpol, cnf)
 		}
 	}
 
 	for _, cjob := range allObjects.CronJobs() {
 		o := newObject(cjob.CronJob().TypeMeta, cjob.CronJob().ObjectMeta)
 		for _, test := range allChecks.CronJobs() {
-			o.Add(test.Fn(cjob.CronJob()), test.Check, cjob)
+			o.Add(test.Fn(cjob.CronJob()), test.Check, cjob, cnf)
 		}
 	}
 
 	for _, hpa := range allObjects.HorizontalPodAutoscalers() {
 		o := newObject(hpa.GetTypeMeta(), hpa.GetObjectMeta())
 		for _, test := range allChecks.HorizontalPodAutoscalers() {
-			o.Add(test.Fn(hpa), test.Check, hpa)
+			o.Add(test.Fn(hpa), test.Check, hpa, cnf)
 		}
 	}
 

--- a/score/security_test.go
+++ b/score/security_test.go
@@ -266,3 +266,27 @@ func TestContainerSeccompAllGood(t *testing.T) {
 		EnabledOptionalTests: structMap,
 	}, "Container Seccomp Profile", scorecard.GradeAllOK)
 }
+
+func TestNetworkPolicyIgnoreNamespace(t *testing.T) {
+	t.Parallel()
+
+	structMap := make(map[string]struct{})
+	structMap["testspacedd"] = struct{}{}
+
+	testExpectedScoreWithConfig(t, config.Configuration{
+		AllFiles:             []ks.NamedReader{testFile("networkpolicy-cronjob-not-matching-selector.yaml")},
+		KubernetesVersion: config.Semver{1, 18},
+		IgnoredNamespaces: structMap,
+	}, "NetworkPolicy targets Pod", scorecard.GradeCritical)
+
+	structMapCorrect := make(map[string]struct{})
+	structMapCorrect["testspace"] = struct{}{}
+
+	sc, _ := testScore(config.Configuration{
+		AllFiles: []ks.NamedReader{testFile("networkpolicy-cronjob-not-matching-selector.yaml")},
+		KubernetesVersion: config.Semver{1, 18},
+		IgnoredNamespaces: structMapCorrect,
+	});
+
+	assert.Equal(t, sc, scorecard.Scorecard{})
+}

--- a/scorecard/scorecard.go
+++ b/scorecard/scorecard.go
@@ -2,6 +2,7 @@ package scorecard
 
 import (
 	"fmt"
+	"github.com/zegl/kube-score/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
 
@@ -89,7 +90,7 @@ func (so ScoredObject) HumanFriendlyRef() string {
 	return s
 }
 
-func (so *ScoredObject) Add(ts TestScore, check ks.Check, locationer ks.FileLocationer) {
+func (so *ScoredObject) Add(ts TestScore, check ks.Check, locationer ks.FileLocationer, cnf config.Configuration) {
 	ts.Check = check
 	so.FileLocation = locationer.FileLocation()
 
@@ -97,6 +98,11 @@ func (so *ScoredObject) Add(ts TestScore, check ks.Check, locationer ks.FileLoca
 	if _, ok := so.ignoredChecks[check.ID]; ok {
 		ts.Skipped = true
 		ts.Comments = []TestScoreComment{{Summary: fmt.Sprintf("Skipped because %s is ignored", check.ID)}}
+	}
+
+	if _, ok := cnf.IgnoredNamespaces[so.ObjectMeta.Namespace]; ok {
+		ts.Skipped = true
+		ts.Comments = []TestScoreComment{{Summary: fmt.Sprintf("Skipped because %s namespace is ignored", so.ObjectMeta.Namespace)}}
 	}
 
 	so.Checks = append(so.Checks, ts)


### PR DESCRIPTION
This features adds the ability to disable tests on the specified
namespaces.

Specific usage example:

``` shellsession
kube-score score --ignore-namespace=logging,minio -
```

This usecase is specifically for ignore the checks on namespace like
`istio-system` which isn't managed by us.

Also, this is my first time writing Go code. So I could be totally doing things wrong/non idiomatic way.

<!--
    Optional: Add this change to the release notes by adding a RELNOTE comment
    If this shouldn't appear in the notes, simply remove this.
-->

```
RELNOTE: Add ability to disable test on specified namespaces by using --ignore-namespace option
```
