### PR TITLE
Helmv3 Support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,6 +48,15 @@ dockers:
   binaries:
   - kube-score
   image_templates:
+  - "zegl/kube-score:{{ .Tag }}-helm3"
+  - "zegl/kube-score:latest-helm3"
+  dockerfile: cmd/kube-score/helm3.Dockerfile
+
+- goos: linux
+  goarch: amd64
+  binaries:
+  - kube-score
+  image_templates:
   - "zegl/kube-score:{{ .Tag }}-kustomize"
   - "zegl/kube-score:latest-kustomize"
   dockerfile: cmd/kube-score/kustomize.Dockerfile

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ kubectl api-resources --verbs=list --namespaced -o name \
 ### Example with Docker
 
 ```bash
-docker run -v $(pwd):/project zegl/kube-score:v1.7.0 score my-app/*.yaml
+docker run -v $(pwd):/project zegl/kube-score:v1.10.0 score my-app/*.yaml
 ```
 
 ## Configuration

--- a/cmd/kube-score/helm3.Dockerfile
+++ b/cmd/kube-score/helm3.Dockerfile
@@ -1,0 +1,18 @@
+FROM debian:stretch as downloader
+
+ARG HELM_VERSION=v3.5.0
+ARG HELM_SHA256SUM="3fff0354d5fba4c73ebd5db59a59db72f8a5bbe1117a0b355b0c2983e98db95b"
+
+RUN apt-get update && \
+    apt-get install -y curl && \
+    curl --location "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" > helm.tar.gz && \
+    echo "${HELM_SHA256SUM}  helm.tar.gz" | sha256sum --check && \
+    tar xzvf helm.tar.gz && \
+    chmod +x /linux-amd64/helm
+
+FROM alpine:3.10.1
+RUN apk update && \
+    apk upgrade && \
+    apk add bash ca-certificates
+COPY --from=downloader /linux-amd64/helm /usr/bin/helm
+COPY kube-score /usr/bin/kube-score


### PR DESCRIPTION
… seperate kube-score:<tag>-helm3, updated readme for docker run example to v1.10.0 to match current version.

<!--
    Optional: Add this change to the release notes by adding a RELNOTE comment
    If this shouldn't appear in the notes, simply remove this.
-->

```
RELNOTE: added support for helm v3 and created new dockerfile and tagging.  eg. docker pull zegl/kube-score:v1.10.0-helm3
```
