### PR TITLE
Accept if readiness/liveness probes are the same but differ in threshold

### DIFF
--- a/score/probe_test.go
+++ b/score/probe_test.go
@@ -36,6 +36,12 @@ func TestProbesPodIdenticalTCP(t *testing.T) {
 	assert.Equal(t, "Container has the same readiness and liveness probe", comments[0].Summary)
 }
 
+func TestProbesPodTCPDifferentThresholds(t *testing.T) {
+	t.Parallel()
+	comments := testExpectedScore(t, "pod-probes-tcp-different-thresholds.yaml", "Pod Probes", scorecard.GradeAllOK)
+	assert.Len(t, comments, 0)
+}
+
 func TestProbesPodIdenticalExec(t *testing.T) {
 	t.Parallel()
 	comments := testExpectedScore(t, "pod-probes-identical-exec.yaml", "Pod Probes", scorecard.GradeCritical)

--- a/score/probes/probes.go
+++ b/score/probes/probes.go
@@ -84,6 +84,13 @@ func containerProbes(allServices []ks.Service) func(corev1.PodTemplateSpec, meta
 					}
 				}
 
+				// Accept if readiness/liveness probes are the same (e.g. port) but differ in threshold.
+				// Use case: restart container if application not ready for a longer time, which may work
+				// if application stalled or deadlocked.
+				if r.InitialDelaySeconds != l.InitialDelaySeconds || r.PeriodSeconds != l.PeriodSeconds || r.FailureThreshold != l.FailureThreshold {
+					probesAreIdentical = false
+				}
+
 			}
 		}
 

--- a/score/testdata/pod-probes-tcp-different-thresholds.yaml
+++ b/score/testdata/pod-probes-tcp-different-thresholds.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-test-1
+  labels:
+    app: test
+spec:
+  containers:
+  - name: foobar
+    image: foo/bar:latest
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+      failureThreshold: 3
+    livenessProbe:
+      tcpSocket:
+        port: 8080
+      failureThreshold: 12
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: test
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080


### PR DESCRIPTION
```
RELNOTE: Accept if readiness/liveness probes are the same but differ in threshold
```

Fixes https://github.com/zegl/kube-score/issues/339