### PR TITLE
score/apps: fix statefulset selector labels check

### DIFF
--- a/score/apps_test.go
+++ b/score/apps_test.go
@@ -88,12 +88,17 @@ func TestStatefulsetHasServiceNameDifferentNamespace(t *testing.T) {
 	testExpectedScore(t, "statefulset-service-name-not-headless.yaml", "StatefulSet has ServiceName", scorecard.GradeCritical)
 }
 
+func TestStatefulsetHasServiceNameNotHeadless(t *testing.T) {
+	t.Parallel()
+	testExpectedScore(t, "statefulset-service-name-not-headless.yaml", "StatefulSet has ServiceName", scorecard.GradeCritical)
+}
+
 func TestStatefulsetHasServiceNameDifferentLabel(t *testing.T) {
 	t.Parallel()
 	testExpectedScore(t, "statefulset-service-name-different-label.yaml", "StatefulSet has ServiceName", scorecard.GradeCritical)
 }
 
-func TestStatefulsetHasServiceNameNotHeadless(t *testing.T) {
+func TestStatefulsetSelectorLabels(t *testing.T) {
 	t.Parallel()
-	testExpectedScore(t, "statefulset-service-name-not-headless.yaml", "StatefulSet has ServiceName", scorecard.GradeCritical)
+	testExpectedScore(t, "statefulset-different-labels.yaml", "StatefulSet Pod Selector labels match template metadata labels", scorecard.GradeCritical)
 }

--- a/score/security_test.go
+++ b/score/security_test.go
@@ -2,12 +2,13 @@ package score
 
 import (
 	"bytes"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
-	"testing"
 
 	"github.com/zegl/kube-score/config"
 	ks "github.com/zegl/kube-score/domain"
@@ -192,6 +193,11 @@ func TestPodSecurityContext(test *testing.T) {
 				APIVersion: "apps/v1",
 			},
 			Spec: appsv1.StatefulSetSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": "foo",
+					},
+				},
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						SecurityContext: tc.podCtx,

--- a/score/testdata/networkpolicy-statefulset-matching.yaml
+++ b/score/testdata/networkpolicy-statefulset-matching.yaml
@@ -17,6 +17,9 @@ metadata:
   name: statefulset-test-1
   namespace: testspace
 spec:
+  selector:
+    matchLabels:
+      app: foo
   template:
     metadata:
       labels:

--- a/score/testdata/networkpolicy-statefulset-not-matching-selector.yaml
+++ b/score/testdata/networkpolicy-statefulset-not-matching-selector.yaml
@@ -17,6 +17,9 @@ metadata:
   name: statefulset-test-1
   namespace: testspace
 spec:
+  selector:
+    matchLabels:
+      app: foo
   template:
     metadata:
       labels:

--- a/score/testdata/statefulset-appsv1beta1.yaml
+++ b/score/testdata/statefulset-appsv1beta1.yaml
@@ -3,6 +3,9 @@ kind: StatefulSet
 metadata:
   name: statefulset-test-1
 spec:
+  selector:
+    matchLabels:
+      app: foo
   template:
     spec:
       containers:

--- a/score/testdata/statefulset-appsv1beta2.yaml
+++ b/score/testdata/statefulset-appsv1beta2.yaml
@@ -3,6 +3,9 @@ kind: StatefulSet
 metadata:
   name: statefulset-test-1
 spec:
+  selector:
+    matchLabels:
+      app: foo
   template:
     spec:
       containers:

--- a/score/testdata/statefulset-different-labels.yaml
+++ b/score/testdata/statefulset-different-labels.yaml
@@ -6,12 +6,12 @@ spec:
   selector:
     matchLabels:
       app: foo
+  serviceName: svc-test-1
   template:
+    metadata:
+      labels:
+        app: bar
     spec:
       containers:
       - name: foobar
         image: foo/bar:123
-        resources:
-          limits:
-            cpu: 200m
-            memory: 1Gi

--- a/score/testdata/statefulset-host-antiaffinity-1-replica.yaml
+++ b/score/testdata/statefulset-host-antiaffinity-1-replica.yaml
@@ -3,6 +3,9 @@ kind: StatefulSet
 metadata:
   name: statefulset-host-antiaffinity-1-replica
 spec:
+  selector:
+    matchLabels:
+      app: foo
   replicas: 1
   template:
     metadata:

--- a/score/testdata/statefulset-host-antiaffinity-not-set.yaml
+++ b/score/testdata/statefulset-host-antiaffinity-not-set.yaml
@@ -3,6 +3,9 @@ kind: StatefulSet
 metadata:
   name: statefulset-anti-affinity-not-set
 spec:
+  selector:
+    matchLabels:
+      app: foo
   replicas: 10
   template:
     metadata:

--- a/score/testdata/statefulset-host-antiaffinity-preffered.yaml
+++ b/score/testdata/statefulset-host-antiaffinity-preffered.yaml
@@ -3,6 +3,9 @@ kind: StatefulSet
 metadata:
   name: statefulset-preffered-anti-affinity
 spec:
+  selector:
+    matchLabels:
+      app: foo
   replicas: 10
   template:
     metadata:
@@ -16,8 +19,8 @@ spec:
             podAffinityTerm:
               labelSelector:
                 matchExpressions:
-                - key: app 
-                  operator: In 
+                - key: app
+                  operator: In
                   values:
                   - foo
               topologyKey: kubernetes.io/hostname

--- a/score/testdata/statefulset-host-antiaffinity-required.yaml
+++ b/score/testdata/statefulset-host-antiaffinity-required.yaml
@@ -3,6 +3,9 @@ kind: StatefulSet
 metadata:
   name: statefulset-required-anti-affinity
 spec:
+  selector:
+    matchLabels:
+      app: foo
   replicas: 10
   template:
     metadata:

--- a/score/testdata/statefulset-host-antiaffinity-undefined-replicas.yaml
+++ b/score/testdata/statefulset-host-antiaffinity-undefined-replicas.yaml
@@ -3,6 +3,9 @@ kind: StatefulSet
 metadata:
   name: statefulset-host-antiaffinity-undefined-replicas
 spec:
+  selector:
+    matchLabels:
+      app: foo
   template:
     metadata:
       labels:

--- a/score/testdata/statefulset-poddisruptionbudget-v1beta1-expression-matches.yaml
+++ b/score/testdata/statefulset-poddisruptionbudget-v1beta1-expression-matches.yaml
@@ -15,6 +15,9 @@ kind: StatefulSet
 metadata:
   name: statefulset-test-1
 spec:
+  selector:
+    matchLabels:
+      app: foo
   template:
     metadata:
       labels:

--- a/score/testdata/statefulset-poddisruptionbudget-v1beta1-expression-no-match.yaml
+++ b/score/testdata/statefulset-poddisruptionbudget-v1beta1-expression-no-match.yaml
@@ -15,6 +15,9 @@ kind: StatefulSet
 metadata:
   name: statefulset-test-1
 spec:
+  selector:
+    matchLabels:
+      app: foo
   template:
     metadata:
       labels:

--- a/score/testdata/statefulset-poddisruptionbudget-v1beta1-matches.yaml
+++ b/score/testdata/statefulset-poddisruptionbudget-v1beta1-matches.yaml
@@ -13,6 +13,9 @@ kind: StatefulSet
 metadata:
   name: statefulset-test-1
 spec:
+  selector:
+    matchLabels:
+      app: foo
   template:
     metadata:
       labels:

--- a/score/testdata/statefulset-poddisruptionbudget-v1beta1-no-match.yaml
+++ b/score/testdata/statefulset-poddisruptionbudget-v1beta1-no-match.yaml
@@ -13,6 +13,9 @@ kind: StatefulSet
 metadata:
   name: statefulset-test-1
 spec:
+  selector:
+    matchLabels:
+      app: foo
   template:
     metadata:
       labels:

--- a/score/testdata/statefulset-service-name-different-label.yaml
+++ b/score/testdata/statefulset-service-name-different-label.yaml
@@ -16,6 +16,9 @@ kind: StatefulSet
 metadata:
   name: statefulset-test-1
 spec:
+  selector:
+    matchLabels:
+      app: foo
   serviceName: svc-test-1
   template:
     metadata:

--- a/score/testdata/statefulset-service-name-different-name.yaml
+++ b/score/testdata/statefulset-service-name-different-name.yaml
@@ -16,6 +16,9 @@ kind: StatefulSet
 metadata:
   name: statefulset-test-1
 spec:
+  selector:
+    matchLabels:
+      app: foo
   serviceName: svc-test-1
   template:
     metadata:

--- a/score/testdata/statefulset-service-name-different-namespace.yaml
+++ b/score/testdata/statefulset-service-name-different-namespace.yaml
@@ -18,6 +18,9 @@ metadata:
   name: statefulset-test-1
   namespace: ns-test-1
 spec:
+  selector:
+    matchLabels:
+      app: foo
   serviceName: svc-test-1
   template:
     metadata:

--- a/score/testdata/statefulset-service-name-not-headless.yaml
+++ b/score/testdata/statefulset-service-name-not-headless.yaml
@@ -15,6 +15,9 @@ kind: StatefulSet
 metadata:
   name: statefulset-test-1
 spec:
+  selector:
+    matchLabels:
+      app: foo
   serviceName: svc-test-1
   template:
     metadata:

--- a/score/testdata/statefulset-service-name.yaml
+++ b/score/testdata/statefulset-service-name.yaml
@@ -16,6 +16,9 @@ kind: StatefulSet
 metadata:
   name: statefulset-test-1
 spec:
+  selector:
+    matchLabels:
+      app: foo
   serviceName: svc-test-1
   template:
     metadata:


### PR DESCRIPTION
Based on https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector

This fixes #336

<!--
    Optional: Add this change to the release notes by adding a RELNOTE comment
    If this shouldn't appear in the notes, simply remove this.
-->

```
RELNOTE: Add StatefulSet selector labels check
```
