### PR TITLE
Upgrade Go, Alpine, and Helm dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-    - image: circleci/golang:1.15
+    - image: circleci/golang:1.17
     working_directory: /go/app
     steps:
     - checkout

--- a/cmd/kube-score/helm.Dockerfile
+++ b/cmd/kube-score/helm.Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     tar xzvf helm.tar.gz && \
     chmod +x /linux-amd64/helm
 
-FROM alpine:3.10.1
+FROM alpine:3.14.2
 RUN apk update && \
     apk upgrade && \
     apk add bash ca-certificates

--- a/cmd/kube-score/helm.Dockerfile
+++ b/cmd/kube-score/helm.Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stretch as downloader
 
-ARG HELM_VERSION=v2.14.3
-ARG HELM_SHA256SUM="38614a665859c0f01c9c1d84fa9a5027364f936814d1e47839b05327e400bf55"
+ARG HELM_VERSION=v2.17.0
+ARG HELM_SHA256SUM="f3bec3c7c55f6a9eb9e6586b8c503f370af92fe987fcbf741f37707606d70296"
 
 RUN apt-get update && \
     apt-get install -y curl && \

--- a/cmd/kube-score/helm3.Dockerfile
+++ b/cmd/kube-score/helm3.Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     tar xzvf helm.tar.gz && \
     chmod +x /linux-amd64/helm
 
-FROM alpine:3.10.1
+FROM alpine:3.14.2
 RUN apk update && \
     apk upgrade && \
     apk add bash ca-certificates

--- a/cmd/kube-score/helm3.Dockerfile
+++ b/cmd/kube-score/helm3.Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stretch as downloader
 
-ARG HELM_VERSION=v3.5.0
-ARG HELM_SHA256SUM="3fff0354d5fba4c73ebd5db59a59db72f8a5bbe1117a0b355b0c2983e98db95b"
+ARG HELM_VERSION=v3.6.3
+ARG HELM_SHA256SUM="07c100849925623dc1913209cd1a30f0a9b80a5b4d6ff2153c609d11b043e262"
 
 RUN apt-get update && \
     apt-get install -y curl && \


### PR DESCRIPTION
<!--
    Optional: Add this change to the release notes by adding a RELNOTE comment
    If this shouldn't appear in the notes, simply remove this.
-->

```
RELNOTE: Upgrade alpine to 3.14.2. Upgrade Go to 1.17. Upgrade Helm 2 to v2.17.0. Upgrade Helm 3 to v3.6.3.
```
