### PR TITLE
Do not panic on empty http block in ingress

### DIFF
--- a/parser/internal/ingress.go
+++ b/parser/internal/ingress.go
@@ -73,12 +73,17 @@ func (i IngressV1beta1) Rules() []networkingv1.IngressRule {
 	}
 
 	for _, rule := range i.Spec.Rules {
+		var http *networkingv1.HTTPIngressRuleValue
+		if rule.HTTP != nil {
+			http = &networkingv1.HTTPIngressRuleValue{
+				Paths: paths(rule.HTTP.Paths),
+			}
+		}
+
 		res = append(res, networkingv1.IngressRule{
 			Host: rule.Host,
 			IngressRuleValue: networkingv1.IngressRuleValue{
-				HTTP: &networkingv1.HTTPIngressRuleValue{
-					Paths: paths(rule.HTTP.Paths),
-				},
+				HTTP: http,
 			},
 		})
 	}
@@ -121,12 +126,17 @@ func (i ExtensionsIngressV1beta1) Rules() []networkingv1.IngressRule {
 	}
 
 	for _, rule := range i.Spec.Rules {
+		var http *networkingv1.HTTPIngressRuleValue
+		if rule.HTTP != nil {
+			http = &networkingv1.HTTPIngressRuleValue{
+				Paths: paths(rule.HTTP.Paths),
+			}
+		}
+
 		res = append(res, networkingv1.IngressRule{
 			Host: rule.Host,
 			IngressRuleValue: networkingv1.IngressRuleValue{
-				HTTP: &networkingv1.HTTPIngressRuleValue{
-					Paths: paths(rule.HTTP.Paths),
-				},
+				HTTP: http,
 			},
 		})
 	}

--- a/score/ingress_test.go
+++ b/score/ingress_test.go
@@ -45,3 +45,8 @@ func TestIngressNoPanicIssue363(t *testing.T) {
 	t.Parallel()
 	testExpectedScore(t, "ingress_issue363.yaml", "Ingress targets Service", scorecard.GradeCritical)
 }
+
+func TestIngressNoPanicIssue388(t *testing.T) {
+	t.Parallel()
+	testExpectedScore(t, "ingress_issue388.yaml", "Ingress targets Service", scorecard.GradeAllOK)
+}

--- a/score/testdata/ingress_issue388.yaml
+++ b/score/testdata/ingress_issue388.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: app-ingress
+  namespace: testspace
+spec:
+  rules:
+    - host: foo.bar.network
+      # No http block — such ingresses can be used for redirects in nginx-ingress
+  tls:
+    - hosts:
+        - foo.bar.network


### PR DESCRIPTION
Fixes #388

```
RELNOTE: Fix panic for Ingresses with empty http blocks . This affected the `networking/v1beta1` and `extensions/v1beta1` versions of Ingress.
```