### PR TITLE
score: add check for PodDisruptionBudget with no policy

### DIFF
--- a/domain/kube-score.go
+++ b/domain/kube-score.go
@@ -2,10 +2,12 @@ package domain
 
 import (
 	"io"
+
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -127,7 +129,10 @@ type CronJobs interface {
 }
 
 type PodDisruptionBudget interface {
+	GetTypeMeta() metav1.TypeMeta
+	GetObjectMeta() metav1.ObjectMeta
 	Namespace() string
+	Spec() policyv1.PodDisruptionBudgetSpec
 	PodDisruptionBudgetSelector() *metav1.LabelSelector
 	FileLocationer
 }

--- a/parser/internal/pdb/pod.go
+++ b/parser/internal/pdb/pod.go
@@ -13,6 +13,14 @@ type PodDisruptionBudgetV1beta1 struct {
 	Location ks.FileLocation
 }
 
+func (p PodDisruptionBudgetV1beta1) GetObjectMeta() metav1.ObjectMeta {
+	return p.Obj.ObjectMeta
+}
+
+func (p PodDisruptionBudgetV1beta1) GetTypeMeta() metav1.TypeMeta {
+	return p.Obj.TypeMeta
+}
+
 func (p PodDisruptionBudgetV1beta1) PodDisruptionBudgetSelector() *metav1.LabelSelector {
 	return p.Obj.Spec.Selector
 }
@@ -25,9 +33,21 @@ func (p PodDisruptionBudgetV1beta1) FileLocation() ks.FileLocation {
 	return p.Location
 }
 
+func (p PodDisruptionBudgetV1beta1) Spec() policyv1.PodDisruptionBudgetSpec {
+	return policyv1.PodDisruptionBudgetSpec(p.Obj.Spec)
+}
+
 type PodDisruptionBudgetV1 struct {
 	Obj      policyv1.PodDisruptionBudget
 	Location ks.FileLocation
+}
+
+func (p PodDisruptionBudgetV1) GetObjectMeta() metav1.ObjectMeta {
+	return p.Obj.ObjectMeta
+}
+
+func (p PodDisruptionBudgetV1) GetTypeMeta() metav1.TypeMeta {
+	return p.Obj.TypeMeta
 }
 
 func (p PodDisruptionBudgetV1) PodDisruptionBudgetSelector() *metav1.LabelSelector {
@@ -40,4 +60,8 @@ func (p PodDisruptionBudgetV1) FileLocation() ks.FileLocation {
 
 func (p PodDisruptionBudgetV1) Namespace() string {
 	return p.Obj.Namespace
+}
+
+func (p PodDisruptionBudgetV1) Spec() policyv1.PodDisruptionBudgetSpec {
+	return p.Obj.Spec
 }

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	policyv1 "k8s.io/api/policy/v1"
 	"log"
 	"strings"
 
@@ -21,6 +20,7 @@ import (
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	networkingv1 "k8s.io/api/networking/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -53,6 +53,7 @@ func addToScheme(scheme *runtime.Scheme) {
 	batchv1.AddToScheme(scheme)
 	batchv1beta1.AddToScheme(scheme)
 	policyv1beta1.AddToScheme(scheme)
+	policyv1.AddToScheme(scheme)
 }
 
 type detectKind struct {

--- a/score/disruptionbudget/disruptionbudget.go
+++ b/score/disruptionbudget/disruptionbudget.go
@@ -17,7 +17,7 @@ func Register(allChecks *checks.Checks, budgets ks.PodDisruptionBudgets) {
 	allChecks.RegisterDeploymentCheck("Deployment has PodDisruptionBudget", `Makes sure that all Deployments are targeted by a PDB`, deploymentHas(budgets.PodDisruptionBudgets()))
 }
 
-func hasMatching(budgets []ks.PodDisruptionBudget, namespace string, lables map[string]string) (bool, error) {
+func hasMatching(budgets []ks.PodDisruptionBudget, namespace string, labels map[string]string) (bool, error) {
 	for _, budget := range budgets {
 		if budget.Namespace() != namespace {
 			continue
@@ -28,7 +28,7 @@ func hasMatching(budgets []ks.PodDisruptionBudget, namespace string, lables map[
 			return false, fmt.Errorf("failed to create selector: %v", err)
 		}
 
-		if selector.Matches(internal.MapLables(lables)) {
+		if selector.Matches(internal.MapLables(labels)) {
 			return true, nil
 		}
 	}

--- a/score/poddisruptionbudget_test.go
+++ b/score/poddisruptionbudget_test.go
@@ -46,6 +46,16 @@ func TestDeploymentPodDisruptionBudgetNoMatch(t *testing.T) {
 	testExpectedScore(t, "deployment-poddisruptionbudget-v1beta1-no-match.yaml", "Deployment has PodDisruptionBudget", scorecard.GradeCritical)
 }
 
+func TestDeploymentPodDisruptionBudgetNoPolicy(t *testing.T) {
+	t.Parallel()
+	testExpectedScore(t, "deployment-poddisruptionbudget-v1beta1-no-policy.yaml", "PodDisruptionBudget has policy", scorecard.GradeCritical)
+}
+
+func TestDeploymentPodDisruptionBudgetV1NoPolicy(t *testing.T) {
+	t.Parallel()
+	testExpectedScore(t, "deployment-poddisruptionbudget-v1-no-policy.yaml", "PodDisruptionBudget has policy", scorecard.GradeCritical)
+}
+
 func TestDeploymentPodDisruptionBudgetV1Matches(t *testing.T) {
 	t.Parallel()
 	testExpectedScore(t, "deployment-poddisruptionbudget-v1-matches.yaml", "Deployment has PodDisruptionBudget", scorecard.GradeAllOK)

--- a/score/score.go
+++ b/score/score.go
@@ -134,5 +134,12 @@ func Score(allObjects ks.AllTypes, cnf config.Configuration) (*scorecard.Scoreca
 		}
 	}
 
+	for _, pdb := range allObjects.PodDisruptionBudgets() {
+		o := newObject(pdb.GetTypeMeta(), pdb.GetObjectMeta())
+		for _, test := range allChecks.PodDisruptionBudgets() {
+			o.Add(test.Fn(pdb), test.Check, pdb)
+		}
+	}
+
 	return &scoreCard, nil
 }

--- a/score/testdata/deployment-poddisruptionbudget-v1-no-policy.yaml
+++ b/score/testdata/deployment-poddisruptionbudget-v1-no-policy.yaml
@@ -1,0 +1,22 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: app-budget
+spec:
+  selector:
+    matchLabels:
+      app: foo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: statefulset-test-1
+spec:
+  template:
+    metadata:
+      labels:
+        app: foo
+    spec:
+      containers:
+      - name: foobar
+        image: foo:bar

--- a/score/testdata/deployment-poddisruptionbudget-v1beta1-no-policy.yaml
+++ b/score/testdata/deployment-poddisruptionbudget-v1beta1-no-policy.yaml
@@ -1,0 +1,22 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: app-budget
+spec:
+  selector:
+    matchLabels:
+      app: foo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: statefulset-test-1
+spec:
+  template:
+    metadata:
+      labels:
+        app: foo
+    spec:
+      containers:
+      - name: foobar
+        image: foo:bar


### PR DESCRIPTION
This adds check for PodDisruptionBudget with no policy. PDBs should specify a policy with `minAvailable` or `maxUnavailable`. This test flags PDBs that don't specify either.

This is based on the assumption that the PDB is invalid without `minAvailable` or `maxUnavailable` defined -- do you know of any cases where it's valid to not specify either? I don't. When I've tested a PDB like this in k8s (by accident 😄), the controller sets `.status.expectedPods: 0` regardless of the deployment replicas field.

<!--
    Optional: Add this change to the release notes by adding a RELNOTE comment
    If this shouldn't appear in the notes, simply remove this.
-->

```
RELNOTE: Add check for PodDisruptionBudget with no policy
```
