### PR TITLE
score/apps: support more topology keys

### DIFF
--- a/score/apps/apps_test.go
+++ b/score/apps/apps_test.go
@@ -53,6 +53,66 @@ func antiAffinityTestCases() []testcase {
 			expectedSkipped: false,
 		},
 		{
+			// OK! (required) ( topology.kubernetes.io/zone )
+			expectedGrade: scorecard.GradeAllOK,
+			replicas:      i(5),
+			affinity: &corev1.Affinity{
+				PodAntiAffinity: &corev1.PodAntiAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+						{
+							TopologyKey: "topology.kubernetes.io/zone",
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app": "foo",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedSkipped: false,
+		},
+		{
+			// OK! (required) ( topology.kubernetes.io/region )
+			expectedGrade: scorecard.GradeAllOK,
+			replicas:      i(5),
+			affinity: &corev1.Affinity{
+				PodAntiAffinity: &corev1.PodAntiAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+						{
+							TopologyKey: "topology.kubernetes.io/region",
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app": "foo",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedSkipped: false,
+		},
+		{
+			// Not OK! (required) ( some other topology key )
+			expectedGrade: scorecard.GradeWarning,
+			replicas:      i(5),
+			affinity: &corev1.Affinity{
+				PodAntiAffinity: &corev1.PodAntiAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+						{
+							TopologyKey: "topology.kubernetes.io/what-is-this-key",
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app": "foo",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedSkipped: false,
+		},
+		{
 			// OK (preferred)
 			expectedGrade: scorecard.GradeAllOK,
 			replicas:      i(5),


### PR DESCRIPTION
<p>score/apps: support more topology keys</p><p>Adds support for additional “approved” topology keys in the hasPodAntiAffinity score</p>

Fixes #390

```
RELNOTE: Add support for more topology kets in the hasPodAntiAffinity test
```

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/kube-score-QEduUvS/ec482ab3-1b84-47fc-8b77-3974d49c7dbb) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
