### PR TITLE
Indicate that skipped = True when skipping pod probes

### DIFF
--- a/score/probes/probes.go
+++ b/score/probes/probes.go
@@ -99,6 +99,7 @@ func containerProbes(allServices []ks.Service) func(corev1.PodTemplateSpec, meta
 
 		if !isTargetedByService {
 			score.Grade = scorecard.GradeAllOK
+			score.Skipped = true
 			score.AddComment("", "The pod is not targeted by a service, skipping probe checks.", "")
 			return score
 		}


### PR DESCRIPTION
<!--
    Optional: Add this change to the release notes by adding a RELNOTE comment
    If this shouldn't appear in the notes, simply remove this.
-->

```
RELNOTE: Indicate that skipped = True when skipping pod-probe scans
```

I don't know if tests need to be updated, feel free to push any updates there directly to the fork.