### PR TITLE
score-failure: Prompt on newline of error msg

### DIFF
--- a/cmd/kube-score/main.go
+++ b/cmd/kube-score/main.go
@@ -34,7 +34,7 @@ func main() {
 	cmds := map[string]cmdFunc{
 		"score": func(helpName string, args []string) {
 			if err := scoreFiles(helpName, args); err != nil {
-				_, _ = fmt.Fprintf(os.Stderr, "Failed to score files: %v", err)
+				_, _ = fmt.Fprintf(os.Stderr, "Failed to score files: %v\n", err)
 				os.Exit(1)
 			}
 		},


### PR DESCRIPTION
When scoring of file fails, the error message should
end with a new line so that the terminal prompt
starts on a new line.

Closes: https://github.com/zegl/kube-score/issues/409

Signed-Off-By: Janki Chhatbar <jchhatba@redhat.com>