### PR TITLE
Add Stable check for Ingress

### DIFF
--- a/score/stable/stable_version.go
+++ b/score/stable/stable_version.go
@@ -23,9 +23,10 @@ func metaStableAvailable(kubernetsVersion config.Semver) func(meta domain.BothMe
 
 		withStable := map[string]map[string]recommendedApi{
 			"extensions/v1beta1": {
-				"Deployment": recommendedApi{"apps/v1", config.Semver{1, 9}},
-				"DaemonSet":  recommendedApi{"apps/v1", config.Semver{1, 9}},
-				"Ingress":    recommendedApi{"networking.k8s.io/v1beta1", config.Semver{1, 14}},
+				"Deployment":   recommendedApi{"apps/v1", config.Semver{1, 9}},
+				"DaemonSet":    recommendedApi{"apps/v1", config.Semver{1, 9}},
+				"Ingress":      recommendedApi{"networking.k8s.io/v1", config.Semver{1, 19}},
+				"IngressClass": recommendedApi{"networking.k8s.io/v1", config.Semver{1, 19}},
 			},
 			"apps/v1beta1": {
 				"Deployment":  recommendedApi{"apps/v1", config.Semver{1, 9}},
@@ -41,6 +42,10 @@ func metaStableAvailable(kubernetsVersion config.Semver) func(meta domain.BothMe
 			},
 			"policy/v1beta1": {
 				"PodDisruptionBudget": recommendedApi{"policy/v1", config.Semver{1, 21}},
+			},
+			"networking.k8s.io/v1beta1": {
+				"Ingress":      recommendedApi{"networking.k8s.io/v1", config.Semver{1, 19}},
+				"IngressClass": recommendedApi{"networking.k8s.io/v1", config.Semver{1, 19}},
 			},
 		}
 

--- a/score/stable/stable_version_test.go
+++ b/score/stable/stable_version_test.go
@@ -25,10 +25,10 @@ func TestStableVersionNewKubernetesVersion(t *testing.T) {
 }
 
 func TestStableVersionIngress(t *testing.T) {
-	newKubernetes := metaStableAvailable(config.Semver{1, 18})
+	newKubernetes := metaStableAvailable(config.Semver{1, 20})
 	scoreNew := newKubernetes(ks.BothMeta{TypeMeta: v1.TypeMeta{Kind: "Ingress", APIVersion: "extensions/v1beta1"}})
 	assert.Equal(t, scorecard.GradeWarning, scoreNew.Grade)
-	assert.Equal(t, []scorecard.TestScoreComment{{Path: "", Summary: "The apiVersion and kind extensions/v1beta1/Ingress is deprecated", Description: "It's recommended to use networking.k8s.io/v1beta1 instead which has been available since Kubernetes v1.14", DocumentationURL: ""}}, scoreNew.Comments)
+	assert.Equal(t, []scorecard.TestScoreComment{{Path: "", Summary: "The apiVersion and kind extensions/v1beta1/Ingress is deprecated", Description: "It's recommended to use networking.k8s.io/v1 instead which has been available since Kubernetes v1.19", DocumentationURL: ""}}, scoreNew.Comments)
 }
 
 func TestStableVersionPodDisruptionBudget(t *testing.T) {
@@ -36,4 +36,11 @@ func TestStableVersionPodDisruptionBudget(t *testing.T) {
 	scoreNew := newKubernetes(ks.BothMeta{TypeMeta: v1.TypeMeta{Kind: "PodDisruptionBudget", APIVersion: "policy/v1beta1"}})
 	assert.Equal(t, scorecard.GradeWarning, scoreNew.Grade)
 	assert.Equal(t, []scorecard.TestScoreComment{{Path: "", Summary: "The apiVersion and kind policy/v1beta1/PodDisruptionBudget is deprecated", Description: "It's recommended to use policy/v1 instead which has been available since Kubernetes v1.21", DocumentationURL: ""}}, scoreNew.Comments)
+}
+
+func TestStableNetworkingIngress(t *testing.T) {
+	newKubernetes := metaStableAvailable(config.Semver{1, 21})
+	scoreNew := newKubernetes(ks.BothMeta{TypeMeta: v1.TypeMeta{Kind: "Ingress", APIVersion: "networking.k8s.io/v1beta1"}})
+	assert.Equal(t, scorecard.GradeWarning, scoreNew.Grade)
+	assert.Equal(t, []scorecard.TestScoreComment{{Path: "", Summary: "The apiVersion and kind networking.k8s.io/v1beta1/Ingress is deprecated", Description: "It's recommended to use networking.k8s.io/v1 instead which has been available since Kubernetes v1.19", DocumentationURL: ""}}, scoreNew.Comments)
 }


### PR DESCRIPTION
<p>score/stable: recommend usage of networking.k8s.io/v1</p><p></p><pre><code>RELNOTE: Recommend networking.k8s.io/v1 instead of the deprecated networking.k8s.io/v1beta1 APIs.
</code></pre><p><br>Fixes <a target="_blank" rel="noopener noreferrer nofollow" href="https://github.com/zegl/kube-score/issues/415">#415</a></p>

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/kube-score-QEduUvS/ec482ab3-1b84-47fc-8b77-3974d49c7dbb) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
