### PR TITLE
Split check setup into exported functions

### DIFF
--- a/score/container/container.go
+++ b/score/container/container.go
@@ -3,20 +3,69 @@ package container
 import (
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/zegl/kube-score/config"
 	"github.com/zegl/kube-score/score/checks"
 	"github.com/zegl/kube-score/scorecard"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Register(allChecks *checks.Checks, cnf config.Configuration) {
-	allChecks.RegisterPodCheck("Container Resources", `Makes sure that all pods have resource limits and requests set. The --ignore-container-cpu-limit flag can be used to disable the requirement of having a CPU limit`, containerResources(!cnf.IgnoreContainerCpuLimitRequirement, !cnf.IgnoreContainerMemoryLimitRequirement))
-	allChecks.RegisterOptionalPodCheck("Container Resource Requests Equal Limits", `Makes sure that all pods have the same requests as limits on resources set.`, containerResourceRequestsEqualLimits)
-	allChecks.RegisterOptionalPodCheck("Container CPU Requests Equal Limits", `Makes sure that all pods have the same CPU requests as limits set.`, containerCPURequestsEqualLimits)
-	allChecks.RegisterOptionalPodCheck("Container Memory Requests Equal Limits", `Makes sure that all pods have the same memory requests as limits set.`, containerMemoryRequestsEqualLimits)
-	allChecks.RegisterPodCheck("Container Image Tag", `Makes sure that a explicit non-latest tag is used`, containerImageTag)
-	allChecks.RegisterPodCheck("Container Image Pull Policy", `Makes sure that the pullPolicy is set to Always. This makes sure that imagePullSecrets are always validated.`, containerImagePullPolicy)
+	CheckContainerResources(allChecks, cnf.IgnoreContainerCpuLimitRequirement, cnf.IgnoreContainerMemoryLimitRequirement)
+	CheckContainerResourceRequestsEqualLimits(allChecks)
+	CheckContainerCPURequestsEqualLimits(allChecks)
+	CheckContainerMemoryRequestsEqualLimits(allChecks)
+	CheckContainerImageTag(allChecks)
+	CheckContainerImagePullPolicy(allChecks)
+}
+
+func CheckContainerResources(allChecks *checks.Checks, ignoreContainerCpuLimitRequirement, ignoreContainerMemoryLimitRequirement bool) {
+	allChecks.RegisterPodCheck(
+		"Container Resources",
+		`Makes sure that all pods have resource limits and requests set. The --ignore-container-cpu-limit flag can be used to disable the requirement of having a CPU limit`,
+		containerResources(!ignoreContainerCpuLimitRequirement, !ignoreContainerMemoryLimitRequirement),
+	)
+}
+
+func CheckContainerResourceRequestsEqualLimits(allChecks *checks.Checks) {
+	allChecks.RegisterOptionalPodCheck(
+		"Container Resource Requests Equal Limits",
+		`Makes sure that all pods have the same requests as limits on resources set.`,
+		containerResourceRequestsEqualLimits,
+	)
+}
+
+func CheckContainerCPURequestsEqualLimits(allChecks *checks.Checks) {
+	allChecks.RegisterOptionalPodCheck(
+		"Container CPU Requests Equal Limits",
+		`Makes sure that all pods have the same CPU requests as limits set.`,
+		containerCPURequestsEqualLimits,
+	)
+}
+
+func CheckContainerMemoryRequestsEqualLimits(allChecks *checks.Checks) {
+	allChecks.RegisterOptionalPodCheck(
+		"Container Memory Requests Equal Limits",
+		`Makes sure that all pods have the same memory requests as limits set.`,
+		containerMemoryRequestsEqualLimits,
+	)
+}
+
+func CheckContainerImageTag(allChecks *checks.Checks) {
+	allChecks.RegisterPodCheck(
+		"Container Image Tag",
+		`Makes sure that a explicit non-latest tag is used`,
+		containerImageTag,
+	)
+}
+
+func CheckContainerImagePullPolicy(allChecks *checks.Checks) {
+	allChecks.RegisterPodCheck(
+		"Container Image Pull Policy",
+		`Makes sure that the pullPolicy is set to Always. This makes sure that imagePullSecrets are always validated.`,
+		containerImagePullPolicy,
+	)
 }
 
 // containerResources makes sure that the container has resource requests and limits set

--- a/score/cronjob/cronjob.go
+++ b/score/cronjob/cronjob.go
@@ -7,6 +7,10 @@ import (
 )
 
 func Register(allChecks *checks.Checks) {
+	CheckCronJobHasDeadline(allChecks)
+}
+
+func CheckCronJobHasDeadline(allChecks *checks.Checks) {
 	allChecks.RegisterCronJobCheck("CronJob has deadline", `Makes sure that all CronJobs has a configured deadline`, cronJobHasDeadline)
 }
 

--- a/score/disruptionbudget/disruptionbudget.go
+++ b/score/disruptionbudget/disruptionbudget.go
@@ -13,9 +13,33 @@ import (
 )
 
 func Register(allChecks *checks.Checks, budgets ks.PodDisruptionBudgets) {
-	allChecks.RegisterStatefulSetCheck("StatefulSet has PodDisruptionBudget", `Makes sure that all StatefulSets are targeted by a PDB`, statefulSetHas(budgets.PodDisruptionBudgets()))
-	allChecks.RegisterDeploymentCheck("Deployment has PodDisruptionBudget", `Makes sure that all Deployments are targeted by a PDB`, deploymentHas(budgets.PodDisruptionBudgets()))
-	allChecks.RegisterPodDisruptionBudgetCheck("PodDisruptionBudget has policy", `Makes sure that PodDisruptionBudgets specify minAvailable or maxUnavailable`, hasPolicy)
+	CheckPodDisruptionBudgetHasPolicy(allChecks)
+	CheckStatefulSetHasPodDisruptionBudget(allChecks, budgets)
+	CheckDeploymentHasPodDisruptionBudget(allChecks, budgets)
+}
+
+func CheckStatefulSetHasPodDisruptionBudget(allChecks *checks.Checks, budgets ks.PodDisruptionBudgets) {
+	allChecks.RegisterStatefulSetCheck(
+		"StatefulSet has PodDisruptionBudget",
+		`Makes sure that all StatefulSets are targeted by a PDB`,
+		statefulSetHas(budgets.PodDisruptionBudgets()),
+	)
+}
+
+func CheckDeploymentHasPodDisruptionBudget(allChecks *checks.Checks, budgets ks.PodDisruptionBudgets) {
+	allChecks.RegisterDeploymentCheck(
+		"Deployment has PodDisruptionBudget",
+		`Makes sure that all Deployments are targeted by a PDB`,
+		deploymentHas(budgets.PodDisruptionBudgets()),
+	)
+}
+
+func CheckPodDisruptionBudgetHasPolicy(allChecks *checks.Checks) {
+	allChecks.RegisterPodDisruptionBudgetCheck(
+		"PodDisruptionBudget has policy",
+		`Makes sure that PodDisruptionBudgets specify minAvailable or maxUnavailable`,
+		hasPolicy,
+	)
 }
 
 func hasMatching(budgets []ks.PodDisruptionBudget, namespace string, labels map[string]string) (bool, error) {

--- a/score/hpa/hpa.go
+++ b/score/hpa/hpa.go
@@ -7,6 +7,10 @@ import (
 )
 
 func Register(allChecks *checks.Checks, allTargetableObjs []domain.BothMeta) {
+	CheckHorizontalPodAutoscalerHasTarget(allChecks, allTargetableObjs)
+}
+
+func CheckHorizontalPodAutoscalerHasTarget(allChecks *checks.Checks, allTargetableObjs []domain.BothMeta) {
 	allChecks.RegisterHorizontalPodAutoscalerCheck("HorizontalPodAutoscaler has target", `Makes sure that the HPA targets a valid object`, hpaHasTarget(allTargetableObjs))
 }
 

--- a/score/ingress/ingress.go
+++ b/score/ingress/ingress.go
@@ -9,6 +9,10 @@ import (
 )
 
 func Register(allChecks *checks.Checks, services ks.Services) {
+	CheckIngressTargetsService(allChecks, services)
+}
+
+func CheckIngressTargetsService(allChecks *checks.Checks, services ks.Services) {
 	allChecks.RegisterIngressCheck("Ingress targets Service", `Makes sure that the Ingress targets a Service`, ingressTargetsService(services.Services()))
 }
 

--- a/score/meta/labels.go
+++ b/score/meta/labels.go
@@ -9,7 +9,12 @@ import (
 )
 
 func Register(allChecks *checks.Checks) {
+	CheckLabelValues(allChecks)
+}
+
+func CheckLabelValues(allChecks *checks.Checks) {
 	allChecks.RegisterMetaCheck("Label values", "Validates label values", validateLabelValues)
+
 }
 
 func validateLabelValues(meta domain.BothMeta) (score scorecard.TestScore) {

--- a/score/networkpolicy/networkpolicy.go
+++ b/score/networkpolicy/networkpolicy.go
@@ -12,8 +12,24 @@ import (
 )
 
 func Register(allChecks *checks.Checks, netpols ks.NetworkPolicies, pods ks.Pods, podspecers ks.PodSpeccers) {
-	allChecks.RegisterPodCheck("Pod NetworkPolicy", `Makes sure that all Pods are targeted by a NetworkPolicy`, podHasNetworkPolicy(netpols.NetworkPolicies()))
-	allChecks.RegisterNetworkPolicyCheck("NetworkPolicy targets Pod", `Makes sure that all NetworkPolicies targets at least one Pod`, networkPolicyTargetsPod(pods.Pods(), podspecers.PodSpeccers()))
+	CheckPodNetworkPolicy(allChecks, netpols)
+	CheckNetworkPolicyTargetsPod(allChecks, pods, podspecers)
+}
+
+func CheckPodNetworkPolicy(allChecks *checks.Checks, netpols ks.NetworkPolicies) {
+	allChecks.RegisterPodCheck(
+		"Pod NetworkPolicy",
+		`Makes sure that all Pods are targeted by a NetworkPolicy`,
+		podHasNetworkPolicy(netpols.NetworkPolicies()),
+	)
+}
+
+func CheckNetworkPolicyTargetsPod(allChecks *checks.Checks, pods ks.Pods, podspecers ks.PodSpeccers) {
+	allChecks.RegisterNetworkPolicyCheck(
+		"NetworkPolicy targets Pod",
+		`Makes sure that all NetworkPolicies targets at least one Pod`,
+		networkPolicyTargetsPod(pods.Pods(), podspecers.PodSpeccers()),
+	)
 }
 
 // podHasNetworkPolicy returns a function that tests that all pods have matching NetworkPolicies

--- a/score/probes/probes.go
+++ b/score/probes/probes.go
@@ -11,6 +11,10 @@ import (
 )
 
 func Register(allChecks *checks.Checks, services ks.Services) {
+	CheckPodProbes(allChecks, services)
+}
+
+func CheckPodProbes(allChecks *checks.Checks, services ks.Services) {
 	allChecks.RegisterPodCheck("Pod Probes", `Makes sure that all Pods have safe probe configurations`, containerProbes(services.Services()))
 }
 

--- a/score/score.go
+++ b/score/score.go
@@ -44,9 +44,13 @@ func RegisterAllChecks(allObjects ks.AllTypes, cnf config.Configuration) *checks
 // Score runs a pre-configured list of tests against the files defined in the configuration, and returns a scorecard.
 // Additional configuration and tuning parameters can be provided via the config.
 func Score(allObjects ks.AllTypes, cnf config.Configuration) (*scorecard.Scorecard, error) {
-	allChecks := RegisterAllChecks(allObjects, cnf)
-	scoreCard := scorecard.New()
+	return ForChecks(RegisterAllChecks(allObjects, cnf), allObjects, cnf)
+}
 
+// ForChecks runs the given list of tests against the files defined in the configuration and returns a scorecard.
+// Additional configuration and tuning parameters can be provided via the config.
+func ForChecks(allChecks *checks.Checks, allObjects ks.AllTypes, cnf config.Configuration) (*scorecard.Scorecard, error) {
+	scoreCard := scorecard.New()
 	newObject := func(typeMeta metav1.TypeMeta, objectMeta metav1.ObjectMeta) *scorecard.ScoredObject {
 		return scoreCard.NewObject(typeMeta, objectMeta, cnf.UseIgnoreChecksAnnotation)
 	}

--- a/score/security/security.go
+++ b/score/security/security.go
@@ -9,15 +9,47 @@ import (
 )
 
 func Register(allChecks *checks.Checks) {
-	allChecks.RegisterPodCheck("Container Security Context User Group ID", `Makes sure that all pods have a security context with valid UID and GID set `, containerSecurityContextUserGroupID)
-	allChecks.RegisterPodCheck("Container Security Context Privileged", "Makes sure that all pods have a unprivileged security context set", containerSecurityContextPrivileged)
-	allChecks.RegisterPodCheck("Container Security Context ReadOnlyRootFilesystem", "Makes sure that all pods have a security context with read only filesystem set", containerSecurityContextReadOnlyRootFilesystem)
+	CheckContainerSecurityContextUserGroupID(allChecks)
+	CheckContainerSecurityContextPrivileged(allChecks)
+	CheckContainerSecurityContextReadOnlyRootFilesystem(allChecks)
 
-	allChecks.RegisterOptionalPodCheck("Container Seccomp Profile", `Makes sure that all pods have at a seccomp policy configured.`, podSeccompProfile)
+	CheckContainerSeccompProfile(allChecks)
+}
+
+func CheckContainerSecurityContextUserGroupID(allChecks *checks.Checks) {
+	allChecks.RegisterPodCheck(
+		"Container Security Context User Group ID",
+		`Makes sure that all pods have a security context with valid UID and GID set `,
+		containerSecurityContextUserGroupID,
+	)
+}
+
+func CheckContainerSecurityContextPrivileged(allChecks *checks.Checks) {
+	allChecks.RegisterPodCheck(
+		"Container Security Context Privileged",
+		"Makes sure that all pods have a unprivileged security context set",
+		containerSecurityContextPrivileged,
+	)
+}
+
+func CheckContainerSecurityContextReadOnlyRootFilesystem(allChecks *checks.Checks) {
+	allChecks.RegisterPodCheck(
+		"Container Security Context ReadOnlyRootFilesystem",
+		"Makes sure that all pods have a security context with read only filesystem set",
+		containerSecurityContextReadOnlyRootFilesystem,
+	)
+}
+
+func CheckContainerSeccompProfile(allChecks *checks.Checks) {
+	allChecks.RegisterOptionalPodCheck(
+		"Container Seccomp Profile",
+		`Makes sure that all pods have at a seccomp policy configured.`,
+		podSeccompProfile,
+	)
 }
 
 // containerSecurityContextReadOnlyRootFilesystem checks for pods using writeable root filesystems
-func containerSecurityContextReadOnlyRootFilesystem(podTemplate corev1.PodTemplateSpec, typeMeta metav1.TypeMeta) (score scorecard.TestScore) {
+func containerSecurityContextReadOnlyRootFilesystem(podTemplate corev1.PodTemplateSpec, _ metav1.TypeMeta) (score scorecard.TestScore) {
 	allContainers := podTemplate.Spec.InitContainers
 	allContainers = append(allContainers, podTemplate.Spec.Containers...)
 

--- a/score/service/service.go
+++ b/score/service/service.go
@@ -10,7 +10,15 @@ import (
 )
 
 func Register(allChecks *checks.Checks, pods ks.Pods, podspeccers ks.PodSpeccers) {
+	CheckServiceTargetsPod(allChecks, pods, podspeccers)
+	CheckServiceType(allChecks)
+}
+
+func CheckServiceTargetsPod(allChecks *checks.Checks, pods ks.Pods, podspeccers ks.PodSpeccers) {
 	allChecks.RegisterServiceCheck("Service Targets Pod", `Makes sure that all Services targets a Pod`, serviceTargetsPod(pods.Pods(), podspeccers.PodSpeccers()))
+}
+
+func CheckServiceType(allChecks *checks.Checks) {
 	allChecks.RegisterServiceCheck("Service Type", `Makes sure that the Service type is not NodePort`, serviceType)
 }
 

--- a/score/stable/stable_version.go
+++ b/score/stable/stable_version.go
@@ -10,6 +10,10 @@ import (
 )
 
 func Register(kubernetesVersion config.Semver, allChecks *checks.Checks) {
+	CheckStableVersion(kubernetesVersion, allChecks)
+}
+
+func CheckStableVersion(kubernetesVersion config.Semver, allChecks *checks.Checks) {
 	allChecks.RegisterMetaCheck("Stable version", `Checks if the object is using a deprecated apiVersion`, metaStableAvailable(kubernetesVersion))
 }
 


### PR DESCRIPTION
By splitting the checks setup into a function-per-check way kube-score is easier to be used as a library like mentioned in #419.