### PR TITLE
Simplified boolean checks and case-insensitive string comparison.

### DIFF
--- a/score/apps/apps.go
+++ b/score/apps/apps.go
@@ -32,7 +32,7 @@ func hpaDeploymentNoReplicas(allHPAs []ks.HpaTargeter) func(deployment appsv1.De
 			target := hpa.HpaTarget()
 
 			if hpa.GetObjectMeta().Namespace == deployment.Namespace &&
-				strings.ToLower(target.Kind) == strings.ToLower(deployment.Kind) &&
+				strings.EqualFold(target.Kind, deployment.Kind) &&
 				target.Name == deployment.Name {
 
 				if deployment.Spec.Replicas == nil {

--- a/score/security/security.go
+++ b/score/security/security.go
@@ -31,7 +31,7 @@ func containerSecurityContextReadOnlyRootFilesystem(podTemplate corev1.PodTempla
 			continue
 		}
 		sec := container.SecurityContext
-		if sec.ReadOnlyRootFilesystem == nil || *sec.ReadOnlyRootFilesystem == false {
+		if sec.ReadOnlyRootFilesystem == nil || !*sec.ReadOnlyRootFilesystem {
 			hasWritableRootFS = true
 			score.AddComment(container.Name, "The pod has a container with a writable root filesystem", "Set securityContext.readOnlyRootFilesystem to true")
 		}

--- a/scorecard/scorecard.go
+++ b/scorecard/scorecard.go
@@ -59,7 +59,7 @@ type ScoredObject struct {
 
 func (s ScoredObject) AnyBelowOrEqualToGrade(threshold Grade) bool {
 	for _, o := range s.Checks {
-		if o.Skipped == false && o.Grade <= threshold {
+		if !o.Skipped && o.Grade <= threshold {
 			return true
 		}
 	}


### PR DESCRIPTION
I experimented a bit with various linters from https://golangci-lint.run/ and found a couple of fairly trivial things to fix/optimize.

`strings.EqualFold` is quite a bit faster compared than using `toLower()` https://hackernoon.com/optimizing-string-comparisons-in-go-7h1b3udm 

I'm not sure how you feel about sorting go imports.

In `score/score_test.go` this bit is marked as dead code.
```
type unnamedReader struct {
	io.Reader
}

func (unnamedReader) Name() string {
	return ""
}
```

Thanks for a neat tool :tada: