### PR TITLE
Fixes: missing containerPort not detected #416

### DIFF
--- a/score/container/container.go
+++ b/score/container/container.go
@@ -19,6 +19,7 @@ func Register(allChecks *checks.Checks, cnf config.Configuration) {
 	allChecks.RegisterPodCheck("Container Image Pull Policy", `Makes sure that the pullPolicy is set to Always. This makes sure that imagePullSecrets are always validated.`, containerImagePullPolicy)
 	allChecks.RegisterPodCheck("Container Ephemeral Storage Request and Limit", "Makes sure all pods have ephemeral-storage requests and limits set", containerStorageEphemeralRequestAndLimit)
 	allChecks.RegisterOptionalPodCheck("Container Ephemeral Storage Request Equals Limit", "Make sure all pods have matching ephemeral-storage requests and limits", containerStorageEphemeralRequestEqualsLimit)
+	allChecks.RegisterOptionalPodCheck("Container Ports Check", "Container Ports Checks", containerPortsCheck)
 }
 
 // containerResources makes sure that the container has resource requests and limits set
@@ -241,6 +242,28 @@ func containerStorageEphemeralRequestEqualsLimit(podTemplate corev1.PodTemplateS
 			if !requests.StorageEphemeral().Equal(*limits.StorageEphemeral()) {
 				score.AddComment(container.Name, "Ephemeral Storage request does not match limit", "Having equal requests and limits is recommended to avoid node resource DDOS during spikes")
 				score.Grade = scorecard.GradeCritical
+			}
+		}
+	}
+
+	return
+}
+
+func containerPortsCheck(podTemplate corev1.PodTemplateSpec, typeMeta metav1.TypeMeta) (score scorecard.TestScore) {
+
+	allContainers := podTemplate.Spec.InitContainers
+	allContainers = append(allContainers, podTemplate.Spec.Containers...)
+
+	score.Grade = scorecard.GradeAllOK
+
+	for _, container := range allContainers {
+		for _, port := range container.Ports {
+			if port.ContainerPort == 0 {
+				score.AddComment(container.Name, "Container Port Check", "Container ports.containerPort cannot be empty")
+				score.Grade = scorecard.GradeCritical
+			} else if port.HostPort == 0 {
+				score.AddComment(container.Name, "Container Port Check", "Container ports.hostPort not set. Do you intend to expose this service outside the cluster?")
+				score.Grade = scorecard.GradeWarning
 			}
 		}
 	}

--- a/score/score_test.go
+++ b/score/score_test.go
@@ -359,16 +359,16 @@ func TestPodContainerPortsContainerPortMissing(t *testing.T) {
 	}, "Container Ports Check", scorecard.GradeCritical)
 }
 
-func TestPodContainerPortsHostPortMissing(t *testing.T) {
+func TestPodContainerPortsDuplicateNames(t *testing.T) {
 	t.Parallel()
 
 	structMap := make(map[string]struct{})
 	structMap["container-ports-check"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-container-ports-missing-hostport.yaml")},
+		AllFiles:             []ks.NamedReader{testFile("pod-container-ports-duplicate-names.yaml")},
 		EnabledOptionalTests: structMap,
-	}, "Container Ports Check", scorecard.GradeWarning)
+	}, "Container Ports Check", scorecard.GradeCritical)
 }
 
 func TestPodContainerPortsOK(t *testing.T) {
@@ -381,5 +381,4 @@ func TestPodContainerPortsOK(t *testing.T) {
 		AllFiles:             []ks.NamedReader{testFile("pod-container-ports-ok.yaml")},
 		EnabledOptionalTests: structMap,
 	}, "Container Ports Check", scorecard.GradeAllOK)
-
 }

--- a/score/score_test.go
+++ b/score/score_test.go
@@ -347,3 +347,39 @@ func TestPodContainerStorageEphemeralRequestNoMatchLimit(t *testing.T) {
 		EnabledOptionalTests: structMap,
 	}, "Container Ephemeral Storage Request Equals Limit", scorecard.GradeCritical)
 }
+
+func TestPodContainerPortsContainerPortMissing(t *testing.T) {
+	t.Parallel()
+	structMap := make(map[string]struct{})
+	structMap["container-ports-check"] = struct{}{}
+
+	testExpectedScoreWithConfig(t, config.Configuration{
+		AllFiles:             []ks.NamedReader{testFile("pod-container-ports-missing-containerport.yaml")},
+		EnabledOptionalTests: structMap,
+	}, "Container Ports Check", scorecard.GradeCritical)
+}
+
+func TestPodContainerPortsHostPortMissing(t *testing.T) {
+	t.Parallel()
+
+	structMap := make(map[string]struct{})
+	structMap["container-ports-check"] = struct{}{}
+
+	testExpectedScoreWithConfig(t, config.Configuration{
+		AllFiles:             []ks.NamedReader{testFile("pod-container-ports-missing-hostport.yaml")},
+		EnabledOptionalTests: structMap,
+	}, "Container Ports Check", scorecard.GradeWarning)
+}
+
+func TestPodContainerPortsOK(t *testing.T) {
+	t.Parallel()
+
+	structMap := make(map[string]struct{})
+	structMap["container-ports-check"] = struct{}{}
+
+	testExpectedScoreWithConfig(t, config.Configuration{
+		AllFiles:             []ks.NamedReader{testFile("pod-container-ports-ok.yaml")},
+		EnabledOptionalTests: structMap,
+	}, "Container Ports Check", scorecard.GradeAllOK)
+
+}

--- a/score/testdata/pod-container-ports-duplicate-names.yaml
+++ b/score/testdata/pod-container-ports-duplicate-names.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+  labels:
+    app: app
+spec:
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      containers:
+      - name: app
+        image: app:dev
+        imagePullPolicy: "Always"
+        ports:
+        - name: app
+          containerPort: 80
+          protocol: TCP
+        - name: app 
+          containerPort: 8080
+          protocol: TCP

--- a/score/testdata/pod-container-ports-missing-containerport.yaml
+++ b/score/testdata/pod-container-ports-missing-containerport.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+  labels:
+    app: app
+spec:
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      containers:
+      - name: app
+        image: app:dev
+        imagePullPolicy: "Always"
+        ports:
+        - name: app
+          containerPort: 80
+          protocol: TCP
+        - name: smtp
+          containerPort: 
+          protocol: TCP

--- a/score/testdata/pod-container-ports-ok.yaml
+++ b/score/testdata/pod-container-ports-ok.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+  labels:
+    app: app
+spec:
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      containers:
+      - name: app
+        image: app:dev
+        imagePullPolicy: "Always"
+        ports:
+        - name: app
+          containerPort: 80
+          hostPort: 8080
+          protocol: TCP
+        - name: smtp
+          containerPort: 25
+          hostPort: 465
+          protocol: TCP


### PR DESCRIPTION
<!--
    Optional: Add this change to the release notes by adding a RELNOTE comment
    If this shouldn't appear in the notes, simply remove this.
-->

```
RELNOTE: Implements an optional Pod container ports test. Checks to ensure a ports containerPort value isn't missing and name ports are unique.
```
