### PR TITLE
Introduce golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,11 @@ jobs:
     - run:
         name: "Enforce Go Formatted Code"
         command: "! go fmt github.com/zegl/kube-score/... 2>&1 | read"
+    - run:
+        name: "Validate lint"
+        command: |
+          curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.20.0
+          golangci-lint run
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
     - run:
         name: "Validate lint"
         command: |
-          curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.20.0
+          curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.2
           golangci-lint run
 
 workflows:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,29 @@
+
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    # - errcheck
+    - gosimple
+    # - govet
+    - ineffassign
+    # - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
+    - bodyclose
+    - contextcheck
+    - cyclop
+    - durationcheck
+    # - errname
+    - errorlint
+    - exportloopref
+    - goimports
+    - gosec
+    - gocritic
+
+linters-settings:
+  cyclop:
+    max-complexity: 35
+

--- a/cmd/kube-score/help_test.go
+++ b/cmd/kube-score/help_test.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestExecName(t *testing.T) {

--- a/config/semver_test.go
+++ b/config/semver_test.go
@@ -1,8 +1,9 @@
 package config
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSemver(t *testing.T) {

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -133,7 +133,7 @@ func ParseFiles(cnf config.Configuration) (ks.AllTypes, error) {
 		}
 
 		// Convert to unix style newlines
-		fullFile = bytes.Replace(fullFile, []byte("\r\n"), []byte("\n"), -1)
+		fullFile = bytes.ReplaceAll(fullFile, []byte("\r\n"), []byte("\n"))
 
 		offset := 1 // Line numbers are 1 indexed
 

--- a/renderer/human/human.go
+++ b/renderer/human/human.go
@@ -39,11 +39,12 @@ func Human(scoreCard *scorecard.Scorecard, verboseOutput int, termWidth int) io.
 		// Adjust to termsize
 		fmt.Fprintf(w, safeRepeat(" ", min(80, termWidth)-writtenHeaderChars-2))
 
-		if scoredObject.AnyBelowOrEqualToGrade(scorecard.GradeCritical) {
+		switch {
+		case scoredObject.AnyBelowOrEqualToGrade(scorecard.GradeCritical):
 			fmt.Fprintf(w, "💥\n")
-		} else if scoredObject.AnyBelowOrEqualToGrade(scorecard.GradeWarning) {
+		case scoredObject.AnyBelowOrEqualToGrade(scorecard.GradeWarning):
 			fmt.Fprintf(w, "🤔\n")
-		} else {
+		default:
 			fmt.Fprintf(w, "✅\n")
 		}
 
@@ -66,7 +67,8 @@ func outputHumanStep(card scorecard.TestScore, verboseOutput int, termWidth int)
 
 	var col color.Attribute
 
-	if card.Skipped || card.Grade >= scorecard.GradeAllOK {
+	switch {
+	case card.Skipped || card.Grade >= scorecard.GradeAllOK:
 		// Higher than or equal to --threshold-ok
 		col = color.FgGreen
 
@@ -75,10 +77,10 @@ func outputHumanStep(card scorecard.TestScore, verboseOutput int, termWidth int)
 			return w
 		}
 
-	} else if card.Grade >= scorecard.GradeWarning {
+	case card.Grade >= scorecard.GradeWarning:
 		// Higher than or equal to --threshold-warning
 		col = color.FgYellow
-	} else {
+	default:
 		// All lower than both --threshold-ok and --threshold-warning are critical
 		col = color.FgRed
 	}

--- a/renderer/json_v2/api.go
+++ b/renderer/json_v2/api.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ks "github.com/zegl/kube-score/domain"

--- a/score/checks/checks.go
+++ b/score/checks/checks.go
@@ -43,7 +43,7 @@ func NewCheck(name, targetType, comment string, optional bool) ks.Check {
 
 func machineFriendlyName(in string) string {
 	in = strings.ToLower(in)
-	in = strings.Replace(in, " ", "-", -1)
+	in = strings.ReplaceAll(in, " ", "-")
 	return in
 }
 

--- a/score/container/container.go
+++ b/score/container/container.go
@@ -53,14 +53,15 @@ func containerResources(requireCPULimit bool, requireMemoryLimit bool) func(core
 			}
 		}
 
-		if len(allContainers) == 0 {
+		switch {
+		case len(allContainers) == 0:
 			score.Grade = scorecard.GradeCritical
 			score.AddComment("", "No containers defined", "")
-		} else if hasMissingLimit {
+		case hasMissingLimit:
 			score.Grade = scorecard.GradeCritical
-		} else if hasMissingRequest {
+		case hasMissingRequest:
 			score.Grade = scorecard.GradeWarning
-		} else {
+		default:
 			score.Grade = scorecard.GradeAllOK
 		}
 

--- a/score/container/container_test.go
+++ b/score/container/container_test.go
@@ -1,8 +1,9 @@
 package container
 
 import (
-	"k8s.io/apimachinery/pkg/api/resource"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"

--- a/score/disruptionbudget/disruptionbudget.go
+++ b/score/disruptionbudget/disruptionbudget.go
@@ -26,7 +26,7 @@ func hasMatching(budgets []ks.PodDisruptionBudget, namespace string, labels map[
 
 		selector, err := metav1.LabelSelectorAsSelector(budget.PodDisruptionBudgetSelector())
 		if err != nil {
-			return false, fmt.Errorf("failed to create selector: %v", err)
+			return false, fmt.Errorf("failed to create selector: %w", err)
 		}
 
 		if selector.Matches(internal.MapLables(labels)) {

--- a/score/disruptionbudget/disruptionbudget_test.go
+++ b/score/disruptionbudget/disruptionbudget_test.go
@@ -1,9 +1,10 @@
 package disruptionbudget
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
-	"testing"
 
 	"github.com/zegl/kube-score/scorecard"
 )

--- a/score/filelocation_test.go
+++ b/score/filelocation_test.go
@@ -1,8 +1,9 @@
 package score
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/zegl/kube-score/config"
 	ks "github.com/zegl/kube-score/domain"

--- a/score/hpa/hpa_test.go
+++ b/score/hpa/hpa_test.go
@@ -1,10 +1,11 @@
 package hpa
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 
 	"github.com/zegl/kube-score/domain"
 	"github.com/zegl/kube-score/scorecard"

--- a/score/meta/labels_test.go
+++ b/score/meta/labels_test.go
@@ -1,8 +1,9 @@
 package meta
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/score/networkpolicy/networkpolicy.go
+++ b/score/networkpolicy/networkpolicy.go
@@ -65,15 +65,16 @@ func podHasNetworkPolicy(allNetpols []ks.NetworkPolicy) func(spec corev1.PodTemp
 			}
 		}
 
-		if hasMatchingEgressNetpol && hasMatchingIngressNetpol {
+		switch {
+		case hasMatchingEgressNetpol && hasMatchingIngressNetpol:
 			score.Grade = scorecard.GradeAllOK
-		} else if hasMatchingEgressNetpol && !hasMatchingIngressNetpol {
+		case hasMatchingEgressNetpol && !hasMatchingIngressNetpol:
 			score.Grade = scorecard.GradeWarning
 			score.AddComment("", "The pod does not have a matching ingress NetworkPolicy", "Add a ingress policy to the pods NetworkPolicy")
-		} else if hasMatchingIngressNetpol && !hasMatchingEgressNetpol {
+		case hasMatchingIngressNetpol && !hasMatchingEgressNetpol:
 			score.Grade = scorecard.GradeWarning
 			score.AddComment("", "The pod does not have a matching egress NetworkPolicy", "Add a egress policy to the pods NetworkPolicy")
-		} else {
+		default:
 			score.Grade = scorecard.GradeCritical
 			score.AddComment("", "The pod does not have a matching NetworkPolicy", "Create a NetworkPolicy that targets this pod to control who/what can communicate with this pod. Note, this feature needs to be supported by the CNI implementation used in the Kubernetes cluster to have an effect.")
 		}

--- a/score/networkpolicy/networkpolicy_test.go
+++ b/score/networkpolicy/networkpolicy_test.go
@@ -1,11 +1,12 @@
 package networkpolicy
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 
 	"github.com/zegl/kube-score/domain"
 	"github.com/zegl/kube-score/scorecard"

--- a/score/score_test.go
+++ b/score/score_test.go
@@ -1,7 +1,6 @@
 package score
 
 import (
-	"io"
 	"os"
 	"testing"
 
@@ -58,14 +57,6 @@ func testExpectedScore(t *testing.T, filename string, testcase string, expectedS
 		AllFiles:          []ks.NamedReader{testFile(filename)},
 		KubernetesVersion: config.Semver{1, 18},
 	}, testcase, expectedScore)
-}
-
-type unnamedReader struct {
-	io.Reader
-}
-
-func (unnamedReader) Name() string {
-	return ""
 }
 
 func TestPodContainerNoResources(t *testing.T) {

--- a/score/stable/stable_version_test.go
+++ b/score/stable/stable_version_test.go
@@ -1,9 +1,10 @@
 package stable
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 
 	"github.com/zegl/kube-score/config"
 	ks "github.com/zegl/kube-score/domain"

--- a/scorecard/scorecard.go
+++ b/scorecard/scorecard.go
@@ -2,8 +2,9 @@ package scorecard
 
 import (
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ks "github.com/zegl/kube-score/domain"
 )


### PR DESCRIPTION
There are some commented out linters that create a fair share of warnings, e.g., `govet`. Don't know how you feel about fixing the warnings from them, before merging. 
