### PR TITLE
Ephemeral storage limit check not skipped when "kube-score/ignore": "…

### DIFF
--- a/score/score_test.go
+++ b/score/score_test.go
@@ -339,6 +339,31 @@ func TestPodContainerStorageEphemeralRequestNoMatchLimit(t *testing.T) {
 	}, "Container Ephemeral Storage Request Equals Limit", scorecard.GradeCritical)
 }
 
+func TestPodContainerStorageEphemeralIgnoreAnnotation(t *testing.T) {
+
+	t.Parallel()
+	s, err := testScore(config.Configuration{
+		VerboseOutput:             0,
+		AllFiles:                  []ks.NamedReader{testFile("pod-ephemeral-storage-annotation-ignore.yaml")},
+		UseIgnoreChecksAnnotation: true,
+	})
+	assert.Nil(t, err)
+	assert.Len(t, s, 1)
+
+	tested := false
+
+	for _, o := range s {
+		for _, c := range o.Checks {
+			if c.Check.ID == "container-resources" {
+				assert.True(t, c.Skipped)
+				tested = true
+			}
+		}
+		assert.Equal(t, "pod-ephemeral-storage-annotation-ignore", o.ObjectMeta.Name)
+	}
+	assert.True(t, tested)
+}
+
 func TestPodContainerPortsContainerPortMissing(t *testing.T) {
 	t.Parallel()
 	structMap := make(map[string]struct{})

--- a/score/testdata/pod-ephemeral-storage-annotation-ignore.yaml
+++ b/score/testdata/pod-ephemeral-storage-annotation-ignore.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-ephemeral-storage-annotation-ignore
+  annotations:
+    "kube-score/ignore": 'container-resources'
+spec:
+  containers:
+  - name: foobar
+    image: foo/bar:123
+    resources:
+      limits:
+        cpu: 200m
+        memory: 1Gi
+        ephemeral-storage: 2Gi
+      requests:
+        cpu: 200m


### PR DESCRIPTION
…container-resources" annotation is set #449

<!--
    Optional: Add this change to the release notes by adding a RELNOTE comment
    If this shouldn't appear in the notes, simply remove this.
-->

```
RELNOTE:  

Bugfix:  Container ephemeral storage tests did not honor "kube-score/ignore": "container-resources" annotation because the tests were implemented apart from the extant CPU and memory container tests.  Fix addresses this oversight by noting the "container-resources" annotation implies also ignoring the "container-ephemeral-storage-request-and-limit" tests. 
```
