### PR TITLE
Implement feature request: Annotation in the manifest can be used to specify optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Actions:
 
 Flags for score:
       --disable-ignore-checks-annotations   Set to true to disable the effect of the 'kube-score/ignore' annotations
+      --disable-optional-checks-annotations Set to true to disable the effect of the 'kube-score/optional' annotations
       --enable-optional-test strings        Enable an optional test, can be set multiple times
       --exit-one-on-warning                 Exit with code 1 in case of warnings
       --help                                Print help
@@ -141,6 +142,47 @@ spec:
     port: 80
     targetPort: 8080
   type: NodePort
+```
+
+### Enabling a optional test
+
+Optional tests can be enabled in the whole run of the program, with the `--enable-optional-test` flag.
+
+A test can also be enabled on a per-object basis, by adding the annotation `kube-score/optional` to the object.
+The value should be a comma separated string of the [test IDs](README_CHECKS.md).
+
+Example:
+
+Testing this object will enable the `container-seccomp-profile` test.
+Also multiple tests defined by `kube-score/ignore` are also ignored at the same.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: optional-test-manifest-deployment
+  labels:
+    app: optional-test-manifest
+  annotations:
+    kube-score/ignore: pod-networkpolicy,container-resources,container-image-pull-policy,container-security-context-privileged,container-security-context-user-group-id,container-security-context-readonlyrootfilesystem,container-ephemeral-storage-request-and-limit
+    kube-score/optional: container-seccomp-profile
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: optional-test-manifest
+  template:
+    metadata:
+      labels:
+        app: optional-test-manifest
+    spec:
+      containers:
+      - name: optional-test-manifest
+        image: busybox:1.34
+        command:
+        - /bin/sh
+        - -c
+        - date; env; tail -f /dev/null
 ```
 
 ## Building from source

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Actions:
 
 Flags for score:
       --disable-ignore-checks-annotations   Set to true to disable the effect of the 'kube-score/ignore' annotations
-      --disable-optional-checks-annotations Set to true to disable the effect of the 'kube-score/optional' annotations
+      --disable-optional-checks-annotations Set to true to disable the effect of the 'kube-score/enable' annotations
       --enable-optional-test strings        Enable an optional test, can be set multiple times
       --exit-one-on-warning                 Exit with code 1 in case of warnings
       --help                                Print help
@@ -148,7 +148,7 @@ spec:
 
 Optional tests can be enabled in the whole run of the program, with the `--enable-optional-test` flag.
 
-A test can also be enabled on a per-object basis, by adding the annotation `kube-score/optional` to the object.
+A test can also be enabled on a per-object basis, by adding the annotation `kube-score/enable` to the object.
 The value should be a comma separated string of the [test IDs](README_CHECKS.md).
 
 Example:
@@ -165,7 +165,7 @@ metadata:
     app: optional-test-manifest
   annotations:
     kube-score/ignore: pod-networkpolicy,container-resources,container-image-pull-policy,container-security-context-privileged,container-security-context-user-group-id,container-security-context-readonlyrootfilesystem,container-ephemeral-storage-request-and-limit
-    kube-score/optional: container-seccomp-profile
+    kube-score/enable: container-seccomp-profile
 spec:
   replicas: 1
   selector:

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ Actions:
 
 Flags for score:
       --disable-ignore-checks-annotations   Set to true to disable the effect of the 'kube-score/ignore' annotations
-      --disable-optional-checks-annotations Set to true to disable the effect of the 'kube-score/optional' annotations
-      --enable-optional-test strings        Enable an optional test, can be set multiple times
+      --disable-enable-checks-annotations   Set to true to disable the effect of the 'kube-score/enable' annotations
+      --enable-test strings                 Enable a test, can be set multiple times
       --exit-one-on-warning                 Exit with code 1 in case of warnings
       --help                                Print help
       --ignore-container-cpu-limit          Disables the requirement of setting a container CPU limit
@@ -146,9 +146,9 @@ spec:
 
 ### Enabling a optional test
 
-Optional tests can be enabled in the whole run of the program, with the `--enable-optional-test` flag.
+Optional tests can be enabled in the whole run of the program, with the `--enable-test` flag.
 
-A test can also be enabled on a per-object basis, by adding the annotation `kube-score/optional` to the object.
+A test can also be enabled on a per-object basis, by adding the annotation `kube-score/enable` to the object.
 The value should be a comma separated string of the [test IDs](README_CHECKS.md).
 
 Example:
@@ -165,7 +165,7 @@ metadata:
     app: optional-test-manifest
   annotations:
     kube-score/ignore: pod-networkpolicy,container-resources,container-image-pull-policy,container-security-context-privileged,container-security-context-user-group-id,container-security-context-readonlyrootfilesystem,container-ephemeral-storage-request-and-limit
-    kube-score/optional: container-seccomp-profile
+    kube-score/enable: container-seccomp-profile
 spec:
   replicas: 1
   selector:

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ Actions:
 
 Flags for score:
       --disable-ignore-checks-annotations   Set to true to disable the effect of the 'kube-score/ignore' annotations
-      --disable-enable-checks-annotations   Set to true to disable the effect of the 'kube-score/enable' annotations
-      --enable-test strings                 Enable a test, can be set multiple times
+      --disable-optional-checks-annotations Set to true to disable the effect of the 'kube-score/optional' annotations
+      --enable-optional-test strings        Enable an optional test, can be set multiple times
       --exit-one-on-warning                 Exit with code 1 in case of warnings
       --help                                Print help
       --ignore-container-cpu-limit          Disables the requirement of setting a container CPU limit
@@ -146,9 +146,9 @@ spec:
 
 ### Enabling a optional test
 
-Optional tests can be enabled in the whole run of the program, with the `--enable-test` flag.
+Optional tests can be enabled in the whole run of the program, with the `--enable-optional-test` flag.
 
-A test can also be enabled on a per-object basis, by adding the annotation `kube-score/enable` to the object.
+A test can also be enabled on a per-object basis, by adding the annotation `kube-score/optional` to the object.
 The value should be a comma separated string of the [test IDs](README_CHECKS.md).
 
 Example:
@@ -165,7 +165,7 @@ metadata:
     app: optional-test-manifest
   annotations:
     kube-score/ignore: pod-networkpolicy,container-resources,container-image-pull-policy,container-security-context-privileged,container-security-context-user-group-id,container-security-context-readonlyrootfilesystem,container-ephemeral-storage-request-and-limit
-    kube-score/enable: container-seccomp-profile
+    kube-score/optional: container-seccomp-profile
 spec:
   replicas: 1
   selector:

--- a/cmd/kube-score/main.go
+++ b/cmd/kube-score/main.go
@@ -109,7 +109,7 @@ func scoreFiles(binName string, args []string) error {
 	optionalTests := fs.StringSlice("enable-optional-test", []string{}, "Enable an optional test, can be set multiple times")
 	ignoreTests := fs.StringSlice("ignore-test", []string{}, "Disable a test, can be set multiple times")
 	disableIgnoreChecksAnnotation := fs.Bool("disable-ignore-checks-annotations", false, "Set to true to disable the effect of the 'kube-score/ignore' annotations")
-	disableOptionalChecksAnnotation := fs.Bool("disable-optional-checks-annotations", false, "Set to true to disable the effect of the 'kube-score/optional' annotations")
+	disableOptionalChecksAnnotation := fs.Bool("disable-optional-checks-annotations", false, "Set to true to disable the effect of the 'kube-score/enable' annotations")
 	kubernetesVersion := fs.String("kubernetes-version", "v1.18", "Setting the kubernetes-version will affect the checks ran against the manifests. Set this to the version of Kubernetes that you're using in production for the best results.")
 	setDefault(fs, binName, "score", false)
 

--- a/cmd/kube-score/main.go
+++ b/cmd/kube-score/main.go
@@ -106,10 +106,10 @@ func scoreFiles(binName string, args []string) error {
 	printHelp := fs.Bool("help", false, "Print help")
 	outputFormat := fs.StringP("output-format", "o", "human", "Set to 'human', 'json', 'ci' or 'sarif'. If set to ci, kube-score will output the program in a format that is easier to parse by other programs. Sarif output allows for easier integration with CI platforms.")
 	outputVersion := fs.String("output-version", "", "Changes the version of the --output-format. The 'json' format has version 'v2' (default) and 'v1' (deprecated, will be removed in v1.7.0). The 'human' and 'ci' formats has only version 'v1' (default). If not explicitly set, the default version for that particular output format will be used.")
-	enableTests := fs.StringSlice("enable-test", []string{}, "Enable a test, can be set multiple times")
+	optionalTests := fs.StringSlice("enable-optional-test", []string{}, "Enable an optional test, can be set multiple times")
 	ignoreTests := fs.StringSlice("ignore-test", []string{}, "Disable a test, can be set multiple times")
 	disableIgnoreChecksAnnotation := fs.Bool("disable-ignore-checks-annotations", false, "Set to true to disable the effect of the 'kube-score/ignore' annotations")
-	disableEnableChecksAnnotation := fs.Bool("disable-enable-checks-annotations", false, "Set to true to disable the effect of the 'kube-score/enable' annotations")
+	disableOptionalChecksAnnotation := fs.Bool("disable-optional-checks-annotations", false, "Set to true to disable the effect of the 'kube-score/optional' annotations")
 	kubernetesVersion := fs.String("kubernetes-version", "v1.18", "Setting the kubernetes-version will affect the checks ran against the manifests. Set this to the version of Kubernetes that you're using in production for the best results.")
 	setDefault(fs, binName, "score", false)
 
@@ -158,7 +158,7 @@ Use "-" as filename to read from STDIN.`, execName(binName))
 	}
 
 	ignoredTests := listToStructMap(ignoreTests)
-	enabledTests := listToStructMap(enableTests)
+	enabledOptionalTests := listToStructMap(optionalTests)
 
 	kubeVer, err := config.ParseSemver(*kubernetesVersion)
 	if err != nil {
@@ -171,9 +171,9 @@ Use "-" as filename to read from STDIN.`, execName(binName))
 		IgnoreContainerCpuLimitRequirement:    *ignoreContainerCpuLimit,
 		IgnoreContainerMemoryLimitRequirement: *ignoreContainerMemoryLimit,
 		IgnoredTests:                          ignoredTests,
-		EnabledTests:                          enabledTests,
+		EnabledOptionalTests:                  enabledOptionalTests,
 		UseIgnoreChecksAnnotation:             !*disableIgnoreChecksAnnotation,
-		UseEnableChecksAnnotation:             !*disableEnableChecksAnnotation,
+		UseOptionalChecksAnnotation:           !*disableOptionalChecksAnnotation,
 		KubernetesVersion:                     kubeVer,
 	}
 

--- a/cmd/kube-score/main.go
+++ b/cmd/kube-score/main.go
@@ -106,10 +106,10 @@ func scoreFiles(binName string, args []string) error {
 	printHelp := fs.Bool("help", false, "Print help")
 	outputFormat := fs.StringP("output-format", "o", "human", "Set to 'human', 'json', 'ci' or 'sarif'. If set to ci, kube-score will output the program in a format that is easier to parse by other programs. Sarif output allows for easier integration with CI platforms.")
 	outputVersion := fs.String("output-version", "", "Changes the version of the --output-format. The 'json' format has version 'v2' (default) and 'v1' (deprecated, will be removed in v1.7.0). The 'human' and 'ci' formats has only version 'v1' (default). If not explicitly set, the default version for that particular output format will be used.")
-	optionalTests := fs.StringSlice("enable-optional-test", []string{}, "Enable an optional test, can be set multiple times")
+	enableTests := fs.StringSlice("enable-test", []string{}, "Enable a test, can be set multiple times")
 	ignoreTests := fs.StringSlice("ignore-test", []string{}, "Disable a test, can be set multiple times")
 	disableIgnoreChecksAnnotation := fs.Bool("disable-ignore-checks-annotations", false, "Set to true to disable the effect of the 'kube-score/ignore' annotations")
-	disableOptionalChecksAnnotation := fs.Bool("disable-optional-checks-annotations", false, "Set to true to disable the effect of the 'kube-score/optional' annotations")
+	disableEnableChecksAnnotation := fs.Bool("disable-enable-checks-annotations", false, "Set to true to disable the effect of the 'kube-score/enable' annotations")
 	kubernetesVersion := fs.String("kubernetes-version", "v1.18", "Setting the kubernetes-version will affect the checks ran against the manifests. Set this to the version of Kubernetes that you're using in production for the best results.")
 	setDefault(fs, binName, "score", false)
 
@@ -158,7 +158,7 @@ Use "-" as filename to read from STDIN.`, execName(binName))
 	}
 
 	ignoredTests := listToStructMap(ignoreTests)
-	enabledOptionalTests := listToStructMap(optionalTests)
+	enabledTests := listToStructMap(enableTests)
 
 	kubeVer, err := config.ParseSemver(*kubernetesVersion)
 	if err != nil {
@@ -171,9 +171,9 @@ Use "-" as filename to read from STDIN.`, execName(binName))
 		IgnoreContainerCpuLimitRequirement:    *ignoreContainerCpuLimit,
 		IgnoreContainerMemoryLimitRequirement: *ignoreContainerMemoryLimit,
 		IgnoredTests:                          ignoredTests,
-		EnabledOptionalTests:                  enabledOptionalTests,
+		EnabledTests:                          enabledTests,
 		UseIgnoreChecksAnnotation:             !*disableIgnoreChecksAnnotation,
-		UseOptionalChecksAnnotation:           !*disableOptionalChecksAnnotation,
+		UseEnableChecksAnnotation:             !*disableEnableChecksAnnotation,
 		KubernetesVersion:                     kubeVer,
 	}
 

--- a/cmd/kube-score/main.go
+++ b/cmd/kube-score/main.go
@@ -109,6 +109,7 @@ func scoreFiles(binName string, args []string) error {
 	optionalTests := fs.StringSlice("enable-optional-test", []string{}, "Enable an optional test, can be set multiple times")
 	ignoreTests := fs.StringSlice("ignore-test", []string{}, "Disable a test, can be set multiple times")
 	disableIgnoreChecksAnnotation := fs.Bool("disable-ignore-checks-annotations", false, "Set to true to disable the effect of the 'kube-score/ignore' annotations")
+	disableOptionalChecksAnnotation := fs.Bool("disable-optional-checks-annotations", false, "Set to true to disable the effect of the 'kube-score/optional' annotations")
 	kubernetesVersion := fs.String("kubernetes-version", "v1.18", "Setting the kubernetes-version will affect the checks ran against the manifests. Set this to the version of Kubernetes that you're using in production for the best results.")
 	setDefault(fs, binName, "score", false)
 
@@ -172,6 +173,7 @@ Use "-" as filename to read from STDIN.`, execName(binName))
 		IgnoredTests:                          ignoredTests,
 		EnabledOptionalTests:                  enabledOptionalTests,
 		UseIgnoreChecksAnnotation:             !*disableIgnoreChecksAnnotation,
+		UseOptionalChecksAnnotation:           !*disableOptionalChecksAnnotation,
 		KubernetesVersion:                     kubeVer,
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -15,9 +15,9 @@ type Configuration struct {
 	IgnoreContainerCpuLimitRequirement    bool
 	IgnoreContainerMemoryLimitRequirement bool
 	IgnoredTests                          map[string]struct{}
-	EnabledOptionalTests                  map[string]struct{}
+	EnabledTests                          map[string]struct{}
 	UseIgnoreChecksAnnotation             bool
-	UseOptionalChecksAnnotation           bool
+	UseEnableChecksAnnotation             bool
 	KubernetesVersion                     Semver
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ type Configuration struct {
 	IgnoredTests                          map[string]struct{}
 	EnabledOptionalTests                  map[string]struct{}
 	UseIgnoreChecksAnnotation             bool
+	UseOptionalChecksAnnotation           bool
 	KubernetesVersion                     Semver
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -15,9 +15,9 @@ type Configuration struct {
 	IgnoreContainerCpuLimitRequirement    bool
 	IgnoreContainerMemoryLimitRequirement bool
 	IgnoredTests                          map[string]struct{}
-	EnabledTests                          map[string]struct{}
+	EnabledOptionalTests                  map[string]struct{}
 	UseIgnoreChecksAnnotation             bool
-	UseEnableChecksAnnotation             bool
+	UseOptionalChecksAnnotation           bool
 	KubernetesVersion                     Semver
 }
 

--- a/score/checks/checks.go
+++ b/score/checks/checks.go
@@ -123,22 +123,9 @@ type Checks struct {
 	cnf config.Configuration
 }
 
-func (c Checks) isIgnored(id string) bool {
-	_, ok := c.cnf.IgnoredTests[id]
-	return ok
-}
-
 func (c Checks) isEnabled(check ks.Check) bool {
-	if c.isIgnored(check.ID) {
-		return false
-	}
-
-	if !check.Optional {
-		return true
-	}
-
-	_, ok := c.cnf.EnabledOptionalTests[check.ID]
-	return ok
+	_, ok := c.cnf.IgnoredTests[check.ID]
+	return !ok
 }
 
 func (c *Checks) RegisterMetaCheck(name, comment string, fn MetaCheckFn) {

--- a/score/score.go
+++ b/score/score.go
@@ -48,7 +48,7 @@ func Score(allObjects ks.AllTypes, cnf config.Configuration) (*scorecard.Scoreca
 	scoreCard := scorecard.New()
 
 	newObject := func(typeMeta metav1.TypeMeta, objectMeta metav1.ObjectMeta) *scorecard.ScoredObject {
-		return scoreCard.NewObject(typeMeta, objectMeta, cnf.UseIgnoreChecksAnnotation)
+		return scoreCard.NewObject(typeMeta, objectMeta, cnf)
 	}
 
 	for _, ingress := range allObjects.Ingresses() {

--- a/score/score_test.go
+++ b/score/score_test.go
@@ -112,8 +112,8 @@ func TestPodContainerResourceRequestsEqualLimits(t *testing.T) {
 	structMap["container-resource-requests-equal-limits"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-test-resources-limits-and-requests.yaml")},
-		EnabledOptionalTests: structMap,
+		AllFiles:     []ks.NamedReader{testFile("pod-test-resources-limits-and-requests.yaml")},
+		EnabledTests: structMap,
 	}, "Container Resource Requests Equal Limits", scorecard.GradeAllOK)
 }
 
@@ -124,8 +124,8 @@ func TestPodContainerMemoryRequestsEqualLimits(t *testing.T) {
 	structMap["container-memory-requests-equal-limits"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-test-resources-limits-and-requests.yaml")},
-		EnabledOptionalTests: structMap,
+		AllFiles:     []ks.NamedReader{testFile("pod-test-resources-limits-and-requests.yaml")},
+		EnabledTests: structMap,
 	}, "Container Memory Requests Equal Limits", scorecard.GradeAllOK)
 }
 
@@ -136,8 +136,8 @@ func TestPodContainerCPURequestsEqualLimits(t *testing.T) {
 	structMap["container-cpu-requests-equal-limits"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-test-resources-limits-and-requests.yaml")},
-		EnabledOptionalTests: structMap,
+		AllFiles:     []ks.NamedReader{testFile("pod-test-resources-limits-and-requests.yaml")},
+		EnabledTests: structMap,
 	}, "Container CPU Requests Equal Limits", scorecard.GradeAllOK)
 }
 
@@ -148,8 +148,8 @@ func TestPodContainerResourceRequestsEqualLimitsNoLimits(t *testing.T) {
 	structMap["container-resource-requests-equal-limits"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-test-resources-no-limits.yaml")},
-		EnabledOptionalTests: structMap,
+		AllFiles:     []ks.NamedReader{testFile("pod-test-resources-no-limits.yaml")},
+		EnabledTests: structMap,
 	}, "Container Resource Requests Equal Limits", scorecard.GradeCritical)
 }
 
@@ -157,8 +157,8 @@ func TestPodContainerResourceRequestsEqualLimitsNoLimitsAnnotation(t *testing.T)
 	t.Parallel()
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:                    []ks.NamedReader{testFile("pod-test-resources-no-limits-annotation-optional.yaml")},
-		UseOptionalChecksAnnotation: true,
+		AllFiles:                  []ks.NamedReader{testFile("pod-test-resources-no-limits-annotation-optional.yaml")},
+		UseEnableChecksAnnotation: true,
 	}, "Container Resource Requests Equal Limits", scorecard.GradeCritical)
 }
 
@@ -169,8 +169,8 @@ func TestPodContainerMemoryRequestsEqualLimitsNoLimits(t *testing.T) {
 	structMap["container-memory-requests-equal-limits"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-test-resources-no-limits.yaml")},
-		EnabledOptionalTests: structMap,
+		AllFiles:     []ks.NamedReader{testFile("pod-test-resources-no-limits.yaml")},
+		EnabledTests: structMap,
 	}, "Container Memory Requests Equal Limits", scorecard.GradeCritical)
 }
 
@@ -178,8 +178,8 @@ func TestPodContainerMemoryRequestsEqualLimitsNoLimitsAnnotation(t *testing.T) {
 	t.Parallel()
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:                    []ks.NamedReader{testFile("pod-test-resources-no-limits-annotation-optional.yaml")},
-		UseOptionalChecksAnnotation: true,
+		AllFiles:                  []ks.NamedReader{testFile("pod-test-resources-no-limits-annotation-optional.yaml")},
+		UseEnableChecksAnnotation: true,
 	}, "Container Memory Requests Equal Limits", scorecard.GradeCritical)
 }
 
@@ -190,8 +190,8 @@ func TestPodContainerCPURequestsEqualLimitsNoLimits(t *testing.T) {
 	structMap["container-cpu-requests-equal-limits"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-test-resources-no-limits.yaml")},
-		EnabledOptionalTests: structMap,
+		AllFiles:     []ks.NamedReader{testFile("pod-test-resources-no-limits.yaml")},
+		EnabledTests: structMap,
 	}, "Container CPU Requests Equal Limits", scorecard.GradeCritical)
 }
 
@@ -199,8 +199,8 @@ func TestPodContainerCPURequestsEqualLimitsNoLimitsAnnotation(t *testing.T) {
 	t.Parallel()
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:                    []ks.NamedReader{testFile("pod-test-resources-no-limits-annotation-optional.yaml")},
-		UseOptionalChecksAnnotation: true,
+		AllFiles:                  []ks.NamedReader{testFile("pod-test-resources-no-limits-annotation-optional.yaml")},
+		UseEnableChecksAnnotation: true,
 	}, "Container CPU Requests Equal Limits", scorecard.GradeCritical)
 }
 
@@ -355,8 +355,8 @@ func TestPodContainerStorageEphemeralRequestEqualsLimit(t *testing.T) {
 	structMap["container-ephemeral-storage-request-equals-limit"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-ephemeral-storage-request-matches-limit.yaml")},
-		EnabledOptionalTests: structMap,
+		AllFiles:     []ks.NamedReader{testFile("pod-ephemeral-storage-request-matches-limit.yaml")},
+		EnabledTests: structMap,
 	}, "Container Ephemeral Storage Request Equals Limit", scorecard.GradeAllOK)
 }
 
@@ -367,8 +367,8 @@ func TestPodContainerStorageEphemeralRequestNoMatchLimit(t *testing.T) {
 	structMap["container-ephemeral-storage-request-equals-limit"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-ephemeral-storage-request-nomatch-limit.yaml")},
-		EnabledOptionalTests: structMap,
+		AllFiles:     []ks.NamedReader{testFile("pod-ephemeral-storage-request-nomatch-limit.yaml")},
+		EnabledTests: structMap,
 	}, "Container Ephemeral Storage Request Equals Limit", scorecard.GradeCritical)
 }
 
@@ -376,8 +376,8 @@ func TestPodContainerStorageEphemeralRequestNoMatchLimitAnnotation(t *testing.T)
 	t.Parallel()
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:                    []ks.NamedReader{testFile("pod-ephemeral-storage-request-nomatch-limit-annotation-optional.yaml")},
-		UseOptionalChecksAnnotation: true,
+		AllFiles:                  []ks.NamedReader{testFile("pod-ephemeral-storage-request-nomatch-limit-annotation-optional.yaml")},
+		UseEnableChecksAnnotation: true,
 	}, "Container Ephemeral Storage Request Equals Limit", scorecard.GradeCritical)
 }
 
@@ -412,8 +412,8 @@ func TestPodContainerPortsContainerPortMissing(t *testing.T) {
 	structMap["container-ports-check"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-container-ports-missing-containerport.yaml")},
-		EnabledOptionalTests: structMap,
+		AllFiles:     []ks.NamedReader{testFile("pod-container-ports-missing-containerport.yaml")},
+		EnabledTests: structMap,
 	}, "Container Ports Check", scorecard.GradeCritical)
 }
 
@@ -421,8 +421,8 @@ func TestPodContainerPortsContainerPortMissingAnnotation(t *testing.T) {
 	t.Parallel()
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:                    []ks.NamedReader{testFile("pod-container-ports-missing-containerport-annotation-optional.yaml")},
-		UseOptionalChecksAnnotation: true,
+		AllFiles:                  []ks.NamedReader{testFile("pod-container-ports-missing-containerport-annotation-optional.yaml")},
+		UseEnableChecksAnnotation: true,
 	}, "Container Ports Check", scorecard.GradeCritical)
 }
 
@@ -433,8 +433,8 @@ func TestPodContainerPortsDuplicateNames(t *testing.T) {
 	structMap["container-ports-check"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-container-ports-duplicate-names.yaml")},
-		EnabledOptionalTests: structMap,
+		AllFiles:     []ks.NamedReader{testFile("pod-container-ports-duplicate-names.yaml")},
+		EnabledTests: structMap,
 	}, "Container Ports Check", scorecard.GradeCritical)
 }
 
@@ -445,8 +445,8 @@ func TestPodContainerPortsNameLength(t *testing.T) {
 	structMap["container-ports-check"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-container-ports-name-too-long.yaml")},
-		EnabledOptionalTests: structMap,
+		AllFiles:     []ks.NamedReader{testFile("pod-container-ports-name-too-long.yaml")},
+		EnabledTests: structMap,
 	}, "Container Ports Check", scorecard.GradeCritical)
 }
 
@@ -457,8 +457,8 @@ func TestPodContainerPortsOK(t *testing.T) {
 	structMap["container-ports-check"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-container-ports-ok.yaml")},
-		EnabledOptionalTests: structMap,
+		AllFiles:     []ks.NamedReader{testFile("pod-container-ports-ok.yaml")},
+		EnabledTests: structMap,
 	}, "Container Ports Check", scorecard.GradeAllOK)
 }
 
@@ -469,8 +469,8 @@ func TestPodEnvOK(t *testing.T) {
 	structMap["environment-variable-key-duplication"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-env-ok.yaml")},
-		EnabledOptionalTests: structMap,
+		AllFiles:     []ks.NamedReader{testFile("pod-env-ok.yaml")},
+		EnabledTests: structMap,
 	}, "Environment Variable Key Duplication", scorecard.GradeAllOK)
 }
 
@@ -481,8 +481,8 @@ func TestPodEnvDuplicated(t *testing.T) {
 	structMap["environment-variable-key-duplication"] = struct{}{}
 
 	actual := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-env-duplicated.yaml")},
-		EnabledOptionalTests: structMap,
+		AllFiles:     []ks.NamedReader{testFile("pod-env-duplicated.yaml")},
+		EnabledTests: structMap,
 	}, "Environment Variable Key Duplication", scorecard.GradeCritical)
 
 	expected := []scorecard.TestScoreComment{

--- a/score/score_test.go
+++ b/score/score_test.go
@@ -112,8 +112,8 @@ func TestPodContainerResourceRequestsEqualLimits(t *testing.T) {
 	structMap["container-resource-requests-equal-limits"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-test-resources-limits-and-requests.yaml")},
-		EnabledTests: structMap,
+		AllFiles:             []ks.NamedReader{testFile("pod-test-resources-limits-and-requests.yaml")},
+		EnabledOptionalTests: structMap,
 	}, "Container Resource Requests Equal Limits", scorecard.GradeAllOK)
 }
 
@@ -124,8 +124,8 @@ func TestPodContainerMemoryRequestsEqualLimits(t *testing.T) {
 	structMap["container-memory-requests-equal-limits"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-test-resources-limits-and-requests.yaml")},
-		EnabledTests: structMap,
+		AllFiles:             []ks.NamedReader{testFile("pod-test-resources-limits-and-requests.yaml")},
+		EnabledOptionalTests: structMap,
 	}, "Container Memory Requests Equal Limits", scorecard.GradeAllOK)
 }
 
@@ -136,8 +136,8 @@ func TestPodContainerCPURequestsEqualLimits(t *testing.T) {
 	structMap["container-cpu-requests-equal-limits"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-test-resources-limits-and-requests.yaml")},
-		EnabledTests: structMap,
+		AllFiles:             []ks.NamedReader{testFile("pod-test-resources-limits-and-requests.yaml")},
+		EnabledOptionalTests: structMap,
 	}, "Container CPU Requests Equal Limits", scorecard.GradeAllOK)
 }
 
@@ -148,8 +148,8 @@ func TestPodContainerResourceRequestsEqualLimitsNoLimits(t *testing.T) {
 	structMap["container-resource-requests-equal-limits"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-test-resources-no-limits.yaml")},
-		EnabledTests: structMap,
+		AllFiles:             []ks.NamedReader{testFile("pod-test-resources-no-limits.yaml")},
+		EnabledOptionalTests: structMap,
 	}, "Container Resource Requests Equal Limits", scorecard.GradeCritical)
 }
 
@@ -157,8 +157,8 @@ func TestPodContainerResourceRequestsEqualLimitsNoLimitsAnnotation(t *testing.T)
 	t.Parallel()
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:                  []ks.NamedReader{testFile("pod-test-resources-no-limits-annotation-optional.yaml")},
-		UseEnableChecksAnnotation: true,
+		AllFiles:                    []ks.NamedReader{testFile("pod-test-resources-no-limits-annotation-optional.yaml")},
+		UseOptionalChecksAnnotation: true,
 	}, "Container Resource Requests Equal Limits", scorecard.GradeCritical)
 }
 
@@ -169,8 +169,8 @@ func TestPodContainerMemoryRequestsEqualLimitsNoLimits(t *testing.T) {
 	structMap["container-memory-requests-equal-limits"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-test-resources-no-limits.yaml")},
-		EnabledTests: structMap,
+		AllFiles:             []ks.NamedReader{testFile("pod-test-resources-no-limits.yaml")},
+		EnabledOptionalTests: structMap,
 	}, "Container Memory Requests Equal Limits", scorecard.GradeCritical)
 }
 
@@ -178,8 +178,8 @@ func TestPodContainerMemoryRequestsEqualLimitsNoLimitsAnnotation(t *testing.T) {
 	t.Parallel()
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:                  []ks.NamedReader{testFile("pod-test-resources-no-limits-annotation-optional.yaml")},
-		UseEnableChecksAnnotation: true,
+		AllFiles:                    []ks.NamedReader{testFile("pod-test-resources-no-limits-annotation-optional.yaml")},
+		UseOptionalChecksAnnotation: true,
 	}, "Container Memory Requests Equal Limits", scorecard.GradeCritical)
 }
 
@@ -190,8 +190,8 @@ func TestPodContainerCPURequestsEqualLimitsNoLimits(t *testing.T) {
 	structMap["container-cpu-requests-equal-limits"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-test-resources-no-limits.yaml")},
-		EnabledTests: structMap,
+		AllFiles:             []ks.NamedReader{testFile("pod-test-resources-no-limits.yaml")},
+		EnabledOptionalTests: structMap,
 	}, "Container CPU Requests Equal Limits", scorecard.GradeCritical)
 }
 
@@ -199,8 +199,8 @@ func TestPodContainerCPURequestsEqualLimitsNoLimitsAnnotation(t *testing.T) {
 	t.Parallel()
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:                  []ks.NamedReader{testFile("pod-test-resources-no-limits-annotation-optional.yaml")},
-		UseEnableChecksAnnotation: true,
+		AllFiles:                    []ks.NamedReader{testFile("pod-test-resources-no-limits-annotation-optional.yaml")},
+		UseOptionalChecksAnnotation: true,
 	}, "Container CPU Requests Equal Limits", scorecard.GradeCritical)
 }
 
@@ -355,8 +355,8 @@ func TestPodContainerStorageEphemeralRequestEqualsLimit(t *testing.T) {
 	structMap["container-ephemeral-storage-request-equals-limit"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-ephemeral-storage-request-matches-limit.yaml")},
-		EnabledTests: structMap,
+		AllFiles:             []ks.NamedReader{testFile("pod-ephemeral-storage-request-matches-limit.yaml")},
+		EnabledOptionalTests: structMap,
 	}, "Container Ephemeral Storage Request Equals Limit", scorecard.GradeAllOK)
 }
 
@@ -367,8 +367,8 @@ func TestPodContainerStorageEphemeralRequestNoMatchLimit(t *testing.T) {
 	structMap["container-ephemeral-storage-request-equals-limit"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-ephemeral-storage-request-nomatch-limit.yaml")},
-		EnabledTests: structMap,
+		AllFiles:             []ks.NamedReader{testFile("pod-ephemeral-storage-request-nomatch-limit.yaml")},
+		EnabledOptionalTests: structMap,
 	}, "Container Ephemeral Storage Request Equals Limit", scorecard.GradeCritical)
 }
 
@@ -376,8 +376,8 @@ func TestPodContainerStorageEphemeralRequestNoMatchLimitAnnotation(t *testing.T)
 	t.Parallel()
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:                  []ks.NamedReader{testFile("pod-ephemeral-storage-request-nomatch-limit-annotation-optional.yaml")},
-		UseEnableChecksAnnotation: true,
+		AllFiles:                    []ks.NamedReader{testFile("pod-ephemeral-storage-request-nomatch-limit-annotation-optional.yaml")},
+		UseOptionalChecksAnnotation: true,
 	}, "Container Ephemeral Storage Request Equals Limit", scorecard.GradeCritical)
 }
 
@@ -412,8 +412,8 @@ func TestPodContainerPortsContainerPortMissing(t *testing.T) {
 	structMap["container-ports-check"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-container-ports-missing-containerport.yaml")},
-		EnabledTests: structMap,
+		AllFiles:             []ks.NamedReader{testFile("pod-container-ports-missing-containerport.yaml")},
+		EnabledOptionalTests: structMap,
 	}, "Container Ports Check", scorecard.GradeCritical)
 }
 
@@ -421,8 +421,8 @@ func TestPodContainerPortsContainerPortMissingAnnotation(t *testing.T) {
 	t.Parallel()
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:                  []ks.NamedReader{testFile("pod-container-ports-missing-containerport-annotation-optional.yaml")},
-		UseEnableChecksAnnotation: true,
+		AllFiles:                    []ks.NamedReader{testFile("pod-container-ports-missing-containerport-annotation-optional.yaml")},
+		UseOptionalChecksAnnotation: true,
 	}, "Container Ports Check", scorecard.GradeCritical)
 }
 
@@ -433,8 +433,8 @@ func TestPodContainerPortsDuplicateNames(t *testing.T) {
 	structMap["container-ports-check"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-container-ports-duplicate-names.yaml")},
-		EnabledTests: structMap,
+		AllFiles:             []ks.NamedReader{testFile("pod-container-ports-duplicate-names.yaml")},
+		EnabledOptionalTests: structMap,
 	}, "Container Ports Check", scorecard.GradeCritical)
 }
 
@@ -445,8 +445,8 @@ func TestPodContainerPortsNameLength(t *testing.T) {
 	structMap["container-ports-check"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-container-ports-name-too-long.yaml")},
-		EnabledTests: structMap,
+		AllFiles:             []ks.NamedReader{testFile("pod-container-ports-name-too-long.yaml")},
+		EnabledOptionalTests: structMap,
 	}, "Container Ports Check", scorecard.GradeCritical)
 }
 
@@ -457,8 +457,8 @@ func TestPodContainerPortsOK(t *testing.T) {
 	structMap["container-ports-check"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-container-ports-ok.yaml")},
-		EnabledTests: structMap,
+		AllFiles:             []ks.NamedReader{testFile("pod-container-ports-ok.yaml")},
+		EnabledOptionalTests: structMap,
 	}, "Container Ports Check", scorecard.GradeAllOK)
 }
 
@@ -469,8 +469,8 @@ func TestPodEnvOK(t *testing.T) {
 	structMap["environment-variable-key-duplication"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-env-ok.yaml")},
-		EnabledTests: structMap,
+		AllFiles:             []ks.NamedReader{testFile("pod-env-ok.yaml")},
+		EnabledOptionalTests: structMap,
 	}, "Environment Variable Key Duplication", scorecard.GradeAllOK)
 }
 
@@ -481,8 +481,8 @@ func TestPodEnvDuplicated(t *testing.T) {
 	structMap["environment-variable-key-duplication"] = struct{}{}
 
 	actual := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-env-duplicated.yaml")},
-		EnabledTests: structMap,
+		AllFiles:             []ks.NamedReader{testFile("pod-env-duplicated.yaml")},
+		EnabledOptionalTests: structMap,
 	}, "Environment Variable Key Duplication", scorecard.GradeCritical)
 
 	expected := []scorecard.TestScoreComment{

--- a/score/score_test.go
+++ b/score/score_test.go
@@ -153,6 +153,15 @@ func TestPodContainerResourceRequestsEqualLimitsNoLimits(t *testing.T) {
 	}, "Container Resource Requests Equal Limits", scorecard.GradeCritical)
 }
 
+func TestPodContainerResourceRequestsEqualLimitsNoLimitsAnnotation(t *testing.T) {
+	t.Parallel()
+
+	testExpectedScoreWithConfig(t, config.Configuration{
+		AllFiles:                    []ks.NamedReader{testFile("pod-test-resources-no-limits-annotation-optional.yaml")},
+		UseOptionalChecksAnnotation: true,
+	}, "Container Resource Requests Equal Limits", scorecard.GradeCritical)
+}
+
 func TestPodContainerMemoryRequestsEqualLimitsNoLimits(t *testing.T) {
 	t.Parallel()
 
@@ -165,6 +174,15 @@ func TestPodContainerMemoryRequestsEqualLimitsNoLimits(t *testing.T) {
 	}, "Container Memory Requests Equal Limits", scorecard.GradeCritical)
 }
 
+func TestPodContainerMemoryRequestsEqualLimitsNoLimitsAnnotation(t *testing.T) {
+	t.Parallel()
+
+	testExpectedScoreWithConfig(t, config.Configuration{
+		AllFiles:                    []ks.NamedReader{testFile("pod-test-resources-no-limits-annotation-optional.yaml")},
+		UseOptionalChecksAnnotation: true,
+	}, "Container Memory Requests Equal Limits", scorecard.GradeCritical)
+}
+
 func TestPodContainerCPURequestsEqualLimitsNoLimits(t *testing.T) {
 	t.Parallel()
 
@@ -174,6 +192,15 @@ func TestPodContainerCPURequestsEqualLimitsNoLimits(t *testing.T) {
 	testExpectedScoreWithConfig(t, config.Configuration{
 		AllFiles:             []ks.NamedReader{testFile("pod-test-resources-no-limits.yaml")},
 		EnabledOptionalTests: structMap,
+	}, "Container CPU Requests Equal Limits", scorecard.GradeCritical)
+}
+
+func TestPodContainerCPURequestsEqualLimitsNoLimitsAnnotation(t *testing.T) {
+	t.Parallel()
+
+	testExpectedScoreWithConfig(t, config.Configuration{
+		AllFiles:                    []ks.NamedReader{testFile("pod-test-resources-no-limits-annotation-optional.yaml")},
+		UseOptionalChecksAnnotation: true,
 	}, "Container CPU Requests Equal Limits", scorecard.GradeCritical)
 }
 
@@ -345,6 +372,15 @@ func TestPodContainerStorageEphemeralRequestNoMatchLimit(t *testing.T) {
 	}, "Container Ephemeral Storage Request Equals Limit", scorecard.GradeCritical)
 }
 
+func TestPodContainerStorageEphemeralRequestNoMatchLimitAnnotation(t *testing.T) {
+	t.Parallel()
+
+	testExpectedScoreWithConfig(t, config.Configuration{
+		AllFiles:                    []ks.NamedReader{testFile("pod-ephemeral-storage-request-nomatch-limit-annotation-optional.yaml")},
+		UseOptionalChecksAnnotation: true,
+	}, "Container Ephemeral Storage Request Equals Limit", scorecard.GradeCritical)
+}
+
 func TestPodContainerStorageEphemeralIgnoreAnnotation(t *testing.T) {
 
 	t.Parallel()
@@ -378,6 +414,15 @@ func TestPodContainerPortsContainerPortMissing(t *testing.T) {
 	testExpectedScoreWithConfig(t, config.Configuration{
 		AllFiles:             []ks.NamedReader{testFile("pod-container-ports-missing-containerport.yaml")},
 		EnabledOptionalTests: structMap,
+	}, "Container Ports Check", scorecard.GradeCritical)
+}
+
+func TestPodContainerPortsContainerPortMissingAnnotation(t *testing.T) {
+	t.Parallel()
+
+	testExpectedScoreWithConfig(t, config.Configuration{
+		AllFiles:                    []ks.NamedReader{testFile("pod-container-ports-missing-containerport-annotation-optional.yaml")},
+		UseOptionalChecksAnnotation: true,
 	}, "Container Ports Check", scorecard.GradeCritical)
 }
 

--- a/score/security_test.go
+++ b/score/security_test.go
@@ -16,8 +16,8 @@ func TestContainerSeccompMissing(t *testing.T) {
 	structMap["container-seccomp-profile"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-seccomp-no-annotation.yaml")},
-		EnabledOptionalTests: structMap,
+		AllFiles:     []ks.NamedReader{testFile("pod-seccomp-no-annotation.yaml")},
+		EnabledTests: structMap,
 	}, "Container Seccomp Profile", scorecard.GradeWarning)
 }
 
@@ -28,8 +28,8 @@ func TestContainerSeccompAllGood(t *testing.T) {
 	structMap["container-seccomp-profile"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-seccomp-annotated.yaml")},
-		EnabledOptionalTests: structMap,
+		AllFiles:     []ks.NamedReader{testFile("pod-seccomp-annotated.yaml")},
+		EnabledTests: structMap,
 	}, "Container Seccomp Profile", scorecard.GradeAllOK)
 }
 
@@ -37,8 +37,8 @@ func TestContainerSeccompAllGoodAnnotation(t *testing.T) {
 	t.Parallel()
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:                    []ks.NamedReader{testFile("pod-seccomp-annotated-annotation-optional.yaml")},
-		UseOptionalChecksAnnotation: true,
+		AllFiles:                  []ks.NamedReader{testFile("pod-seccomp-annotated-annotation-optional.yaml")},
+		UseEnableChecksAnnotation: true,
 	}, "Container Seccomp Profile", scorecard.GradeAllOK)
 }
 
@@ -47,8 +47,8 @@ func TestContainerSecurityContextUserGroupIDAllGood(t *testing.T) {
 	structMap := make(map[string]struct{})
 	structMap["container-security-context-user-group-id"] = struct{}{}
 	c := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-security-context-all-good.yaml")},
-		EnabledOptionalTests: structMap,
+		AllFiles:     []ks.NamedReader{testFile("pod-security-context-all-good.yaml")},
+		EnabledTests: structMap,
 	}, "Container Security Context User Group ID", scorecard.GradeAllOK)
 	assert.Empty(t, c)
 }
@@ -58,8 +58,8 @@ func TestContainerSecurityContextUserGroupIDLowGroup(t *testing.T) {
 	optionalChecks := make(map[string]struct{})
 	optionalChecks["container-security-context-user-group-id"] = struct{}{}
 	comments := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-security-context-low-group-id.yaml")},
-		EnabledOptionalTests: optionalChecks,
+		AllFiles:     []ks.NamedReader{testFile("pod-security-context-low-group-id.yaml")},
+		EnabledTests: optionalChecks,
 	}, "Container Security Context User Group ID", scorecard.GradeCritical)
 	assert.Contains(t, comments, scorecard.TestScoreComment{
 		Path:        "foobar",
@@ -73,8 +73,8 @@ func TestContainerSecurityContextUserGroupIDLowUser(t *testing.T) {
 	optionalChecks := make(map[string]struct{})
 	optionalChecks["container-security-context-user-group-id"] = struct{}{}
 	comments := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-security-context-low-user-id.yaml")},
-		EnabledOptionalTests: optionalChecks,
+		AllFiles:     []ks.NamedReader{testFile("pod-security-context-low-user-id.yaml")},
+		EnabledTests: optionalChecks,
 	}, "Container Security Context User Group ID", scorecard.GradeCritical)
 	assert.Contains(t, comments, scorecard.TestScoreComment{
 		Path:        "foobar",
@@ -88,8 +88,8 @@ func TestContainerSecurityContextUserGroupIDNoSecurityContext(t *testing.T) {
 	optionalChecks := make(map[string]struct{})
 	optionalChecks["container-security-context-user-group-id"] = struct{}{}
 	comments := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-security-context-nosecuritycontext.yaml")},
-		EnabledOptionalTests: optionalChecks,
+		AllFiles:     []ks.NamedReader{testFile("pod-security-context-nosecuritycontext.yaml")},
+		EnabledTests: optionalChecks,
 	}, "Container Security Context User Group ID", scorecard.GradeCritical)
 	assert.Contains(t, comments, scorecard.TestScoreComment{
 		Path:        "foobar",
@@ -103,8 +103,8 @@ func TestContainerSecurityContextPrivilegedAllGood(t *testing.T) {
 	structMap := make(map[string]struct{})
 	structMap["container-security-context-privileged"] = struct{}{}
 	c := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-security-context-all-good.yaml")},
-		EnabledOptionalTests: structMap,
+		AllFiles:     []ks.NamedReader{testFile("pod-security-context-all-good.yaml")},
+		EnabledTests: structMap,
 	}, "Container Security Context Privileged", scorecard.GradeAllOK)
 	assert.Empty(t, c)
 }
@@ -114,8 +114,8 @@ func TestContainerSecurityContextPrivilegedPrivileged(t *testing.T) {
 	optionalChecks := make(map[string]struct{})
 	optionalChecks["container-security-context-privileged"] = struct{}{}
 	comments := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-security-context-privileged.yaml")},
-		EnabledOptionalTests: optionalChecks,
+		AllFiles:     []ks.NamedReader{testFile("pod-security-context-privileged.yaml")},
+		EnabledTests: optionalChecks,
 	}, "Container Security Context Privileged", scorecard.GradeCritical)
 	assert.Contains(t, comments, scorecard.TestScoreComment{
 		Path:        "foobar",
@@ -129,8 +129,8 @@ func TestContainerSecurityContextReadOnlyRootFilesystemAllGood(t *testing.T) {
 	structMap := make(map[string]struct{})
 	structMap["container-security-context-readonlyrootfilesystem"] = struct{}{}
 	c := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-security-context-all-good.yaml")},
-		EnabledOptionalTests: structMap,
+		AllFiles:     []ks.NamedReader{testFile("pod-security-context-all-good.yaml")},
+		EnabledTests: structMap,
 	}, "Container Security Context ReadOnlyRootFilesystem", scorecard.GradeAllOK)
 	assert.Empty(t, c)
 }
@@ -140,8 +140,8 @@ func TestContainerSecurityContextReadOnlyRootFilesystemWriteable(t *testing.T) {
 	optionalChecks := make(map[string]struct{})
 	optionalChecks["container-security-context-readonlyrootfilesystem"] = struct{}{}
 	comments := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-security-context-writeablerootfilesystem.yaml")},
-		EnabledOptionalTests: optionalChecks,
+		AllFiles:     []ks.NamedReader{testFile("pod-security-context-writeablerootfilesystem.yaml")},
+		EnabledTests: optionalChecks,
 	}, "Container Security Context ReadOnlyRootFilesystem", scorecard.GradeCritical)
 	assert.Contains(t, comments, scorecard.TestScoreComment{
 		Path:        "foobar",
@@ -155,8 +155,8 @@ func TestContainerSecurityContextReadOnlyRootFilesystemNoSecurityContext(t *test
 	optionalChecks := make(map[string]struct{})
 	optionalChecks["container-security-context-readonlyrootfilesystem"] = struct{}{}
 	comments := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-security-context-nosecuritycontext.yaml")},
-		EnabledOptionalTests: optionalChecks,
+		AllFiles:     []ks.NamedReader{testFile("pod-security-context-nosecuritycontext.yaml")},
+		EnabledTests: optionalChecks,
 	}, "Container Security Context ReadOnlyRootFilesystem", scorecard.GradeCritical)
 	assert.Contains(t, comments, scorecard.TestScoreComment{
 		Path:        "foobar",

--- a/score/security_test.go
+++ b/score/security_test.go
@@ -16,8 +16,8 @@ func TestContainerSeccompMissing(t *testing.T) {
 	structMap["container-seccomp-profile"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-seccomp-no-annotation.yaml")},
-		EnabledTests: structMap,
+		AllFiles:             []ks.NamedReader{testFile("pod-seccomp-no-annotation.yaml")},
+		EnabledOptionalTests: structMap,
 	}, "Container Seccomp Profile", scorecard.GradeWarning)
 }
 
@@ -28,8 +28,8 @@ func TestContainerSeccompAllGood(t *testing.T) {
 	structMap["container-seccomp-profile"] = struct{}{}
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-seccomp-annotated.yaml")},
-		EnabledTests: structMap,
+		AllFiles:             []ks.NamedReader{testFile("pod-seccomp-annotated.yaml")},
+		EnabledOptionalTests: structMap,
 	}, "Container Seccomp Profile", scorecard.GradeAllOK)
 }
 
@@ -37,8 +37,8 @@ func TestContainerSeccompAllGoodAnnotation(t *testing.T) {
 	t.Parallel()
 
 	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:                  []ks.NamedReader{testFile("pod-seccomp-annotated-annotation-optional.yaml")},
-		UseEnableChecksAnnotation: true,
+		AllFiles:                    []ks.NamedReader{testFile("pod-seccomp-annotated-annotation-optional.yaml")},
+		UseOptionalChecksAnnotation: true,
 	}, "Container Seccomp Profile", scorecard.GradeAllOK)
 }
 
@@ -47,8 +47,8 @@ func TestContainerSecurityContextUserGroupIDAllGood(t *testing.T) {
 	structMap := make(map[string]struct{})
 	structMap["container-security-context-user-group-id"] = struct{}{}
 	c := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-security-context-all-good.yaml")},
-		EnabledTests: structMap,
+		AllFiles:             []ks.NamedReader{testFile("pod-security-context-all-good.yaml")},
+		EnabledOptionalTests: structMap,
 	}, "Container Security Context User Group ID", scorecard.GradeAllOK)
 	assert.Empty(t, c)
 }
@@ -58,8 +58,8 @@ func TestContainerSecurityContextUserGroupIDLowGroup(t *testing.T) {
 	optionalChecks := make(map[string]struct{})
 	optionalChecks["container-security-context-user-group-id"] = struct{}{}
 	comments := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-security-context-low-group-id.yaml")},
-		EnabledTests: optionalChecks,
+		AllFiles:             []ks.NamedReader{testFile("pod-security-context-low-group-id.yaml")},
+		EnabledOptionalTests: optionalChecks,
 	}, "Container Security Context User Group ID", scorecard.GradeCritical)
 	assert.Contains(t, comments, scorecard.TestScoreComment{
 		Path:        "foobar",
@@ -73,8 +73,8 @@ func TestContainerSecurityContextUserGroupIDLowUser(t *testing.T) {
 	optionalChecks := make(map[string]struct{})
 	optionalChecks["container-security-context-user-group-id"] = struct{}{}
 	comments := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-security-context-low-user-id.yaml")},
-		EnabledTests: optionalChecks,
+		AllFiles:             []ks.NamedReader{testFile("pod-security-context-low-user-id.yaml")},
+		EnabledOptionalTests: optionalChecks,
 	}, "Container Security Context User Group ID", scorecard.GradeCritical)
 	assert.Contains(t, comments, scorecard.TestScoreComment{
 		Path:        "foobar",
@@ -88,8 +88,8 @@ func TestContainerSecurityContextUserGroupIDNoSecurityContext(t *testing.T) {
 	optionalChecks := make(map[string]struct{})
 	optionalChecks["container-security-context-user-group-id"] = struct{}{}
 	comments := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-security-context-nosecuritycontext.yaml")},
-		EnabledTests: optionalChecks,
+		AllFiles:             []ks.NamedReader{testFile("pod-security-context-nosecuritycontext.yaml")},
+		EnabledOptionalTests: optionalChecks,
 	}, "Container Security Context User Group ID", scorecard.GradeCritical)
 	assert.Contains(t, comments, scorecard.TestScoreComment{
 		Path:        "foobar",
@@ -103,8 +103,8 @@ func TestContainerSecurityContextPrivilegedAllGood(t *testing.T) {
 	structMap := make(map[string]struct{})
 	structMap["container-security-context-privileged"] = struct{}{}
 	c := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-security-context-all-good.yaml")},
-		EnabledTests: structMap,
+		AllFiles:             []ks.NamedReader{testFile("pod-security-context-all-good.yaml")},
+		EnabledOptionalTests: structMap,
 	}, "Container Security Context Privileged", scorecard.GradeAllOK)
 	assert.Empty(t, c)
 }
@@ -114,8 +114,8 @@ func TestContainerSecurityContextPrivilegedPrivileged(t *testing.T) {
 	optionalChecks := make(map[string]struct{})
 	optionalChecks["container-security-context-privileged"] = struct{}{}
 	comments := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-security-context-privileged.yaml")},
-		EnabledTests: optionalChecks,
+		AllFiles:             []ks.NamedReader{testFile("pod-security-context-privileged.yaml")},
+		EnabledOptionalTests: optionalChecks,
 	}, "Container Security Context Privileged", scorecard.GradeCritical)
 	assert.Contains(t, comments, scorecard.TestScoreComment{
 		Path:        "foobar",
@@ -129,8 +129,8 @@ func TestContainerSecurityContextReadOnlyRootFilesystemAllGood(t *testing.T) {
 	structMap := make(map[string]struct{})
 	structMap["container-security-context-readonlyrootfilesystem"] = struct{}{}
 	c := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-security-context-all-good.yaml")},
-		EnabledTests: structMap,
+		AllFiles:             []ks.NamedReader{testFile("pod-security-context-all-good.yaml")},
+		EnabledOptionalTests: structMap,
 	}, "Container Security Context ReadOnlyRootFilesystem", scorecard.GradeAllOK)
 	assert.Empty(t, c)
 }
@@ -140,8 +140,8 @@ func TestContainerSecurityContextReadOnlyRootFilesystemWriteable(t *testing.T) {
 	optionalChecks := make(map[string]struct{})
 	optionalChecks["container-security-context-readonlyrootfilesystem"] = struct{}{}
 	comments := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-security-context-writeablerootfilesystem.yaml")},
-		EnabledTests: optionalChecks,
+		AllFiles:             []ks.NamedReader{testFile("pod-security-context-writeablerootfilesystem.yaml")},
+		EnabledOptionalTests: optionalChecks,
 	}, "Container Security Context ReadOnlyRootFilesystem", scorecard.GradeCritical)
 	assert.Contains(t, comments, scorecard.TestScoreComment{
 		Path:        "foobar",
@@ -155,8 +155,8 @@ func TestContainerSecurityContextReadOnlyRootFilesystemNoSecurityContext(t *test
 	optionalChecks := make(map[string]struct{})
 	optionalChecks["container-security-context-readonlyrootfilesystem"] = struct{}{}
 	comments := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:     []ks.NamedReader{testFile("pod-security-context-nosecuritycontext.yaml")},
-		EnabledTests: optionalChecks,
+		AllFiles:             []ks.NamedReader{testFile("pod-security-context-nosecuritycontext.yaml")},
+		EnabledOptionalTests: optionalChecks,
 	}, "Container Security Context ReadOnlyRootFilesystem", scorecard.GradeCritical)
 	assert.Contains(t, comments, scorecard.TestScoreComment{
 		Path:        "foobar",

--- a/score/security_test.go
+++ b/score/security_test.go
@@ -33,6 +33,15 @@ func TestContainerSeccompAllGood(t *testing.T) {
 	}, "Container Seccomp Profile", scorecard.GradeAllOK)
 }
 
+func TestContainerSeccompAllGoodAnnotation(t *testing.T) {
+	t.Parallel()
+
+	testExpectedScoreWithConfig(t, config.Configuration{
+		AllFiles:                    []ks.NamedReader{testFile("pod-seccomp-annotated-annotation-optional.yaml")},
+		UseOptionalChecksAnnotation: true,
+	}, "Container Seccomp Profile", scorecard.GradeAllOK)
+}
+
 func TestContainerSecurityContextUserGroupIDAllGood(t *testing.T) {
 	t.Parallel()
 	structMap := make(map[string]struct{})

--- a/score/testdata/pod-container-ports-missing-containerport-annotation-optional.yaml
+++ b/score/testdata/pod-container-ports-missing-containerport-annotation-optional.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+  labels:
+    app: app
+  annotations:
+    kube-score/optional: container-ports-check
+spec:
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      containers:
+      - name: app
+        image: app:dev
+        imagePullPolicy: "Always"
+        ports:
+        - name: app
+          containerPort: 80
+          protocol: TCP
+        - name: smtp
+          containerPort: 
+          protocol: TCP

--- a/score/testdata/pod-container-ports-missing-containerport-annotation-optional.yaml
+++ b/score/testdata/pod-container-ports-missing-containerport-annotation-optional.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: app
   annotations:
-    kube-score/enable: container-ports-check
+    kube-score/optional: container-ports-check
 spec:
   selector:
     matchLabels:

--- a/score/testdata/pod-container-ports-missing-containerport-annotation-optional.yaml
+++ b/score/testdata/pod-container-ports-missing-containerport-annotation-optional.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: app
   annotations:
-    kube-score/optional: container-ports-check
+    kube-score/enable: container-ports-check
 spec:
   selector:
     matchLabels:

--- a/score/testdata/pod-ephemeral-storage-request-nomatch-limit-annotation-optional.yaml
+++ b/score/testdata/pod-ephemeral-storage-request-nomatch-limit-annotation-optional.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-test-1
+  annotations:
+    kube-score/optional: container-ephemeral-storage-request-equals-limit
+spec:
+  containers:
+  - name: foobar
+    image: foo/bar:123
+    resources:
+      limits:
+        cpu: 200m
+        memory: 1Gi
+        ephemeral-storage: 2Gi
+      requests:
+        cpu: 200m
+        memory: 1Gi
+        ephemeral-storage: 1Gi

--- a/score/testdata/pod-ephemeral-storage-request-nomatch-limit-annotation-optional.yaml
+++ b/score/testdata/pod-ephemeral-storage-request-nomatch-limit-annotation-optional.yaml
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   name: pod-test-1
   annotations:
-    kube-score/enable: container-ephemeral-storage-request-equals-limit
+    kube-score/optional: container-ephemeral-storage-request-equals-limit
 spec:
   containers:
   - name: foobar

--- a/score/testdata/pod-ephemeral-storage-request-nomatch-limit-annotation-optional.yaml
+++ b/score/testdata/pod-ephemeral-storage-request-nomatch-limit-annotation-optional.yaml
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   name: pod-test-1
   annotations:
-    kube-score/optional: container-ephemeral-storage-request-equals-limit
+    kube-score/enable: container-ephemeral-storage-request-equals-limit
 spec:
   containers:
   - name: foobar

--- a/score/testdata/pod-seccomp-annotated-annotation-optional.yaml
+++ b/score/testdata/pod-seccomp-annotated-annotation-optional.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pod-test-1
   annotations:
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
-    kube-score/optional: container-seccomp-profile
+    kube-score/enable: container-seccomp-profile
 spec:
   containers:
   - name: foobar

--- a/score/testdata/pod-seccomp-annotated-annotation-optional.yaml
+++ b/score/testdata/pod-seccomp-annotated-annotation-optional.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-test-1
+  annotations:
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    kube-score/optional: container-seccomp-profile
+spec:
+  containers:
+  - name: foobar
+    image: foo/bar:latest
+    

--- a/score/testdata/pod-seccomp-annotated-annotation-optional.yaml
+++ b/score/testdata/pod-seccomp-annotated-annotation-optional.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pod-test-1
   annotations:
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
-    kube-score/enable: container-seccomp-profile
+    kube-score/optional: container-seccomp-profile
 spec:
   containers:
   - name: foobar

--- a/score/testdata/pod-test-resources-no-limits-annotation-optional.yaml
+++ b/score/testdata/pod-test-resources-no-limits-annotation-optional.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-test-1
+  annotations:
+    kube-score/optional: container-memory-requests-equal-limits,container-cpu-requests-equal-limits,container-resource-requests-equal-limits
+spec:
+  containers:
+  - name: foobar
+    image: foo/bar:123
+    resources:
+      requests:
+        cpu: 200m
+        memory: 1Gi

--- a/score/testdata/pod-test-resources-no-limits-annotation-optional.yaml
+++ b/score/testdata/pod-test-resources-no-limits-annotation-optional.yaml
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   name: pod-test-1
   annotations:
-    kube-score/optional: container-memory-requests-equal-limits,container-cpu-requests-equal-limits,container-resource-requests-equal-limits
+    kube-score/enable: container-memory-requests-equal-limits,container-cpu-requests-equal-limits,container-resource-requests-equal-limits
 spec:
   containers:
   - name: foobar

--- a/score/testdata/pod-test-resources-no-limits-annotation-optional.yaml
+++ b/score/testdata/pod-test-resources-no-limits-annotation-optional.yaml
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   name: pod-test-1
   annotations:
-    kube-score/enable: container-memory-requests-equal-limits,container-cpu-requests-equal-limits,container-resource-requests-equal-limits
+    kube-score/optional: container-memory-requests-equal-limits,container-cpu-requests-equal-limits,container-resource-requests-equal-limits
 spec:
   containers:
   - name: foobar

--- a/scorecard/scorecard.go
+++ b/scorecard/scorecard.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	ignoredChecksAnnotation  = "kube-score/ignore"
-	optionalChecksAnnotation = "kube-score/optional"
+	optionalChecksAnnotation = "kube-score/enable"
 )
 
 // if this, then that

--- a/scorecard/scorecard.go
+++ b/scorecard/scorecard.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	ignoredChecksAnnotation = "kube-score/ignore"
-	enabledChecksAnnotation = "kube-score/enable"
+	ignoredChecksAnnotation  = "kube-score/ignore"
+	optionalChecksAnnotation = "kube-score/optional"
 )
 
 // if this, then that
@@ -28,11 +28,11 @@ func New() Scorecard {
 
 func (s Scorecard) NewObject(typeMeta metav1.TypeMeta, objectMeta metav1.ObjectMeta, cnf config.Configuration) *ScoredObject {
 	o := &ScoredObject{
-		TypeMeta:      typeMeta,
-		ObjectMeta:    objectMeta,
-		Checks:        make([]TestScore, 0),
-		ignoredChecks: make(map[string]struct{}),
-		enabledChecks: make(map[string]struct{}),
+		TypeMeta:       typeMeta,
+		ObjectMeta:     objectMeta,
+		Checks:         make([]TestScore, 0),
+		ignoredChecks:  make(map[string]struct{}),
+		optionalChecks: make(map[string]struct{}),
 	}
 
 	// If this object already exists, return the previous version
@@ -44,11 +44,11 @@ func (s Scorecard) NewObject(typeMeta metav1.TypeMeta, objectMeta metav1.ObjectM
 		o.setIgnoredTests()
 	}
 
-	if cnf.UseEnableChecksAnnotation {
-		o.setEnabledTests()
+	if cnf.UseOptionalChecksAnnotation {
+		o.setOptionalTests()
 	}
-	for id, ot := range cnf.EnabledTests {
-		o.enabledChecks[id] = ot
+	for id, ot := range cnf.EnabledOptionalTests {
+		o.optionalChecks[id] = ot
 	}
 
 	s[o.resourceRefKey()] = o
@@ -70,8 +70,8 @@ type ScoredObject struct {
 	FileLocation ks.FileLocation
 	Checks       []TestScore
 
-	ignoredChecks map[string]struct{}
-	enabledChecks map[string]struct{}
+	ignoredChecks  map[string]struct{}
+	optionalChecks map[string]struct{}
 }
 
 func (s ScoredObject) AnyBelowOrEqualToGrade(threshold Grade) bool {
@@ -98,14 +98,14 @@ func (so *ScoredObject) setIgnoredTests() {
 	so.ignoredChecks = ignoredMap
 }
 
-func (so *ScoredObject) setEnabledTests() {
-	enabledMap := make(map[string]struct{})
-	if optionalCSV, ok := so.ObjectMeta.Annotations[enabledChecksAnnotation]; ok {
+func (so *ScoredObject) setOptionalTests() {
+	optionalMap := make(map[string]struct{})
+	if optionalCSV, ok := so.ObjectMeta.Annotations[optionalChecksAnnotation]; ok {
 		for _, optional := range strings.Split(optionalCSV, ",") {
-			enabledMap[strings.TrimSpace(optional)] = struct{}{}
+			optionalMap[strings.TrimSpace(optional)] = struct{}{}
 		}
 	}
-	so.enabledChecks = enabledMap
+	so.optionalChecks = optionalMap
 }
 
 func (so ScoredObject) resourceRefKey() string {
@@ -125,7 +125,7 @@ func (so *ScoredObject) Add(ts TestScore, check ks.Check, locationer ks.FileLoca
 	ts.Check = check
 	so.FileLocation = locationer.FileLocation()
 
-	if _, ok := so.enabledChecks[check.ID]; ts.Check.Optional && !ok {
+	if _, ok := so.optionalChecks[check.ID]; ts.Check.Optional && !ok {
 		return
 	}
 


### PR DESCRIPTION
Fixes: #476

## Behavior

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: optional-test-manifest-deployment
  labels:
    app: optional-test-manifest
  annotations:
    kube-score/ignore: pod-networkpolicy,container-resources,container-image-pull-policy,container-security-context-privileged,container-security-context-user-group-id,container-security-context-readonlyrootfilesystem,container-ephemeral-storage-request-and-limit
    kube-score/optional: container-seccomp-profile
spec:
  replicas: 1
  selector:
    matchLabels:
      app: optional-test-manifest
  template:
    metadata:
      labels:
        app: optional-test-manifest
    spec:
      containers:
      - name: optional-test-manifest
        image: busybox:1.34
        command:
        - /bin/sh
        - -c
        - date; env; tail -f /dev/null
```

```
$ kube-score score manifest.yaml
apps/v1/Deployment optional-test-manifest-deployment                          🤔
    [WARNING] Container Seccomp Profile
        · The pod has not configured Seccomp for its containers
            Running containers with Seccomp is recommended to reduce the kernel attack surface
```

### Annotations ignore

```
$ kube-score score manifest.yaml --disable-optional-checks-annotations
apps/v1/Deployment optional-test-manifest-deployment                          ✅
```

### (FYI) Both defined

It will be marked to `ignored`

```yaml
  annotations:
    kube-score/ignore: container-seccomp-profile
    kube-score/optional: container-seccomp-profile
```

```
$ kube-score score manifest.yaml --output-format ci | grep seccomp
[SKIPPED] optional-test-manifest-deployment apps/v1/Deployment: Skipped because container-seccomp-profile is ignored
```
