### PR TITLE
bors: remove

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,2 +1,0 @@
-status = [ 'ci/circleci: test' ]
-delete_merged_branches = true


### PR DESCRIPTION
We don't really need bors anymore. Let's move back to the default GitHub workflows.