### PR TITLE
Enable probe check on pods using serviceAccountName

### DIFF
--- a/score/probe_test.go
+++ b/score/probe_test.go
@@ -15,6 +15,13 @@ func TestProbesPodAllMissing(t *testing.T) {
 	assert.Equal(t, "Container is missing a readinessProbe", comments[0].Summary)
 }
 
+func TestProbesServiceAccountName(t *testing.T) {
+	t.Parallel()
+	comments := testExpectedScore(t, "pod-probes-service-account-name.yaml", "Pod Probes", scorecard.GradeCritical)
+	assert.Len(t, comments, 1)
+	assert.Equal(t, "Container is missing a readinessProbe", comments[0].Summary)
+}
+
 func TestProbesPodMissingReady(t *testing.T) {
 	t.Parallel()
 	comments := testExpectedScore(t, "pod-probes-missing-ready.yaml", "Pod Probes", scorecard.GradeCritical)

--- a/score/probes/probes.go
+++ b/score/probes/probes.go
@@ -41,6 +41,10 @@ func containerProbes(allServices []ks.Service) func(ks.PodSpecer) (scorecard.Tes
 			}
 		}
 
+		if podTemplate.Spec.ServiceAccountName != "" {
+			isTargetedByService = true
+		}
+
 		for _, container := range allContainers {
 			if container.ReadinessProbe != nil {
 				hasReadinessProbe = true

--- a/score/testdata/pod-probes-service-account-name.yaml
+++ b/score/testdata/pod-probes-service-account-name.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-test-1
+  labels:
+    app: test
+spec:
+  serviceAccountName: foobar
+  containers:
+  - name: foobar
+    image: foo/bar:latest


### PR DESCRIPTION
If a pod uses serviceAccountName make sure the probes are being set, as if it's being targeted by a service normally.

```
RELNOTE: If a pod is using a serviceAccountName check probes
```
