### PR TITLE
Ignoring rule container resources makes every rule exceptional #542

### DIFF
--- a/score/testdata/kube-score-ignore-annotations.yaml
+++ b/score/testdata/kube-score-ignore-annotations.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-score-ignore-annotations
+  annotations:
+    "kube-score/ignore": container-security-context-readonlyrootfilesystem,pod-networkpolicy,container-security-context-user-group-id,pod-probes,container-resources
+spec:
+  containers:
+  - name: foobar
+    image: foo/bar:123
+    resources:
+      limits:
+        cpu: 200m
+        memory: 1Gi
+        ephemeral-storage: 2Gi
+      requests:
+        cpu: 200m

--- a/scorecard/enabled.go
+++ b/scorecard/enabled.go
@@ -13,8 +13,12 @@ func (so *ScoredObject) isEnabled(check ks.Check, annotations, childAnnotations 
 			if v == key {
 				return true
 			}
-			if _, ok := impliedIgnoreAnnotations[v]; ok {
-				return true
+			if vals, ok := impliedIgnoreAnnotations[v]; ok {
+				for i := range vals {
+					if vals[i] == key {
+						return true
+					}
+				}
 			}
 		}
 		return false


### PR DESCRIPTION
Fixes #542

```
RELNOTE: Fix bug related to processing implied kube-score/ignore annotations.
```
