### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/cmd/kube-score/main.go
+++ b/cmd/kube-score/main.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -258,7 +257,7 @@ Use "-" as filename to read from STDIN.`, execName(binName))
 		return fmt.Errorf("error: Unknown --output-format or --output-version")
 	}
 
-	output, _ := ioutil.ReadAll(r)
+	output, _ := io.ReadAll(r)
 	fmt.Print(string(output))
 	os.Exit(exitCode)
 	return nil

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"strings"
 
@@ -149,7 +149,7 @@ func (p *Parser) ParseFiles(cnf config.Configuration) (ks.AllTypes, error) {
 	s := &parsedObjects{}
 
 	for _, namedReader := range cnf.AllFiles {
-		fullFile, err := ioutil.ReadAll(namedReader)
+		fullFile, err := io.ReadAll(namedReader)
 		if err != nil {
 			return nil, err
 		}

--- a/renderer/ci/ci_test.go
+++ b/renderer/ci/ci_test.go
@@ -1,7 +1,7 @@
 package ci
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -95,7 +95,7 @@ func TestCiOutput(t *testing.T) {
 	t.Parallel()
 	// Defaults
 	r := CI(getTestCard())
-	all, err := ioutil.ReadAll(r)
+	all, err := io.ReadAll(r)
 	assert.Nil(t, err)
 	assert.Equal(t, `[WARNING] foo/foofoo v1/Testing: (a) summary
 [WARNING] foo/foofoo v1/Testing: summary

--- a/renderer/human/output_test.go
+++ b/renderer/human/output_test.go
@@ -1,7 +1,7 @@
 package human
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -97,7 +97,7 @@ func TestHumanOutputDefault(t *testing.T) {
 	t.Parallel()
 	r, err := Human(getTestCard(), 0, 100, false)
 	assert.Nil(t, err)
-	all, err := ioutil.ReadAll(r)
+	all, err := io.ReadAll(r)
 	assert.Nil(t, err)
 	assert.Equal(t, `v1/Testing foo in foofoo                                                      🤔
     [WARNING] test-warning-two-comments
@@ -120,7 +120,7 @@ func TestHumanOutputVerbose1(t *testing.T) {
 	t.Parallel()
 	r, err := Human(getTestCard(), 1, 100, false)
 	assert.Nil(t, err)
-	all, err := ioutil.ReadAll(r)
+	all, err := io.ReadAll(r)
 	assert.Nil(t, err)
 	assert.Equal(t, `v1/Testing foo in foofoo                                                      🤔
     [WARNING] test-warning-two-comments
@@ -149,7 +149,7 @@ func TestHumanOutputVerbose2(t *testing.T) {
 	t.Parallel()
 	r, err := Human(getTestCard(), 2, 100, false)
 	assert.Nil(t, err)
-	all, err := ioutil.ReadAll(r)
+	all, err := io.ReadAll(r)
 	assert.Nil(t, err)
 	assert.Equal(t, `v1/Testing foo in foofoo                                                      🤔
     [WARNING] test-warning-two-comments
@@ -267,7 +267,7 @@ func TestHumanOutputAllOKDefault(t *testing.T) {
 	t.Parallel()
 	r, err := Human(getTestCardAllOK(), 0, 100, false)
 	assert.Nil(t, err)
-	all, err := ioutil.ReadAll(r)
+	all, err := io.ReadAll(r)
 	assert.Nil(t, err)
 	assert.Equal(t, `v1/Testing foo in foofoo                                                      ✅
 v1/Testing bar-no-namespace                                                   ✅
@@ -310,7 +310,7 @@ func TestHumanOutputLogDescription120Width(t *testing.T) {
 	t.Parallel()
 	r, err := Human(getTestCardLongDescription(), 0, 120, false)
 	assert.Nil(t, err)
-	all, err := ioutil.ReadAll(r)
+	all, err := io.ReadAll(r)
 	assert.Nil(t, err)
 	assert.Equal(t, `v1/Testing foo in foofoo                                                      🤔
     [WARNING] test-warning-two-comments
@@ -326,7 +326,7 @@ func TestHumanOutputLogDescription100Width(t *testing.T) {
 	t.Parallel()
 	r, err := Human(getTestCardLongDescription(), 0, 100, false)
 	assert.Nil(t, err)
-	all, err := ioutil.ReadAll(r)
+	all, err := io.ReadAll(r)
 	assert.Nil(t, err)
 	assert.Equal(t, `v1/Testing foo in foofoo                                                      🤔
     [WARNING] test-warning-two-comments
@@ -343,7 +343,7 @@ func TestHumanOutputLogDescription80Width(t *testing.T) {
 	t.Parallel()
 	r, err := Human(getTestCardLongDescription(), 0, 80, false)
 	assert.Nil(t, err)
-	all, err := ioutil.ReadAll(r)
+	all, err := io.ReadAll(r)
 	assert.Nil(t, err)
 	assert.Equal(t, `v1/Testing foo in foofoo                                                      🤔
     [WARNING] test-warning-two-comments
@@ -361,7 +361,7 @@ func TestHumanOutputLogDescription0Width(t *testing.T) {
 	t.Parallel()
 	r, err := Human(getTestCardLongDescription(), 0, 0, false)
 	assert.Nil(t, err)
-	all, err := ioutil.ReadAll(r)
+	all, err := io.ReadAll(r)
 	assert.Nil(t, err)
 	assert.Equal(t, `v1/Testing foo in foofoo🤔
     [WARNING] test-warning-two-comments
@@ -415,7 +415,7 @@ func TestHumanOutputWithLongObjectNames(t *testing.T) {
 	t.Parallel()
 	r, err := Human(getTestCardLongTitle(), 0, 80, false)
 	assert.Nil(t, err)
-	all, err := ioutil.ReadAll(r)
+	all, err := io.ReadAll(r)
 	assert.Nil(t, err)
 	assert.Equal(t, `v1/Testing this-is-a-very-long-title-this-is-a-very-long-title-this-is-a-very-long-title-this-is-a-very-long-title-this-is-a-very-long-title in foofoo🤔
     [WARNING] test-warning-two-comments


### PR DESCRIPTION
<!--
    Optional: Add this change to the release notes by adding a RELNOTE comment
    If this shouldn't appear in the notes, simply remove this.
-->

```
RELNOTE: describe the changes
```
