### PR TITLE
score/disruptionbudget: output comment when namespace doesn't match

### DIFF
--- a/score/disruptionbudget/disruptionbudget.go
+++ b/score/disruptionbudget/disruptionbudget.go
@@ -21,6 +21,7 @@ func Register(allChecks *checks.Checks, budgets ks.PodDisruptionBudgets) {
 func hasMatching(budgets []ks.PodDisruptionBudget, namespace string, labels map[string]string) (bool, error) {
 	for _, budget := range budgets {
 		if budget.Namespace() != namespace {
+			score.AddComment("", "PodDisruptionBudget namespace didn't match Deployment namespace", "Cannot associate the PodDisruptionBudget to the Deployment because they are not explicitly in the same namespace")
 			continue
 		}
 


### PR DESCRIPTION
I was troubleshooting a strange kube-score failure regarding PodDisruptionBudget.

kube-score was complaining that a deployment didn't have a PDB even though it very much did.

Going back to the code I realized the test was exiting early due to the namespace check:

https://github.com/zegl/kube-score/blob/0b3f154ca3f06a13323431a7d2199a74a1869fbc/score/disruptionbudget/disruptionbudget.go#L23-L25

Obviously, this was a bad manifest on my end (explicit is better than implicit and the tests passed as soon as I added `namespace: {{ .Release.Namespace }}` to my helm charts, but perhaps with a bit more output we could help other folks connect the dots faster.

<!--
    Optional: Add this change to the release notes by adding a RELNOTE comment
    If this shouldn't appear in the notes, simply remove this.
-->

```
RELNOTE: score/disruptionbudget: output comment when namespace doesn't match
```
