### PR TITLE
renderer/human: show file names in case of error or warning

### DIFF
--- a/renderer/human/human.go
+++ b/renderer/human/human.go
@@ -57,6 +57,13 @@ func Human(scoreCard *scorecard.Scorecard, verboseOutput int, termWidth int, use
 			return nil, fmt.Errorf("failed to write: %w", err)
 		}
 
+		// Display file name if the object has any warnings or criticals
+		if scoredObject.AnyBelowOrEqualToGrade(scorecard.GradeWarning) {
+			if scoredObject.FileLocation.Name != "" {
+				_, _ = color.New(color.FgHiBlack).Fprintf(w, "    path=%s\n", scoredObject.FileLocation.Name)
+			}
+		}
+
 		for _, card := range scoredObject.Checks {
 			r := outputHumanStep(card, verboseOutput, termWidth)
 			if _, err := io.Copy(w, r); err != nil {


### PR DESCRIPTION
<img width="1495" alt="Screenshot 2023-08-07 at 13 47 17" src="https://github.com/zegl/kube-score/assets/47952/38db9c6f-4b72-4ac0-9878-fe328d374328">
