### PR TITLE
ci/go: bump Go version from 1.19 to 1.21 and fix CI style

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,15 +5,19 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ["1.19", "1.20", "1.21"]
+        os: [macos-latest, ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
 
       - name: Set up Go
         uses: actions/setup-go@v3
-
         with:
-          go-version: 1.19
+          go-version: ${{ matrix.go-version }}
 
       - name: Build
         run: go build -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN curl --location "https://github.com/kubernetes-sigs/kustomize/releases/downl
     chmod +x kustomize && \
     mv kustomize /usr/bin/kustomize
 
-FROM golang:1.19-alpine as builder
+FROM golang:1.21-alpine as builder
 ARG TARGETARCH
 ARG TARGETPLATFORM
 WORKDIR /kube-score
@@ -67,7 +67,7 @@ COPY --from=builder /usr/bin/kube-score /usr/bin/kube-score
 
 # Symlink to /kube-score for backwards compatibility (with kube-score v1.15.0 and earlier)
 RUN ln -s /usr/bin/kube-score /kube-score
- 
+
 # Dry runs
 RUN /kube-score version && \
     /usr/bin/kube-score version && \

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ spec:
 
 ## Building from source
 
-`kube-score` requires [Go](https://golang.org/) `1.19` or later to build. Clone this repository, and then:
+`kube-score` requires [Go](https://golang.org/) `1.21` or later to build. Clone this repository, and then:
 
 ```bash
 # Build the project
@@ -205,7 +205,7 @@ Do you want to help out? Take a look at the [Contributing Guidelines](./.github/
 
 | Project             | Version |
 |---------------------|---------|
-| go.dev              | ^1.19   | 
+| go.dev              | ^1.21   | 
 
 ## Made by
 

--- a/go.mod
+++ b/go.mod
@@ -35,4 +35,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-go 1.19
+go 1.21


### PR DESCRIPTION
* update Go version due to 1.19 support has already ended
  * https://endoflife.date/go
* to CI run using multiple Go versions and OS types
* doc fix
