### PR TITLE
score/probes: set score.Skipped if pod not targeted by service

### DIFF
--- a/score/probes/probes.go
+++ b/score/probes/probes.go
@@ -99,6 +99,7 @@ func containerProbes(allServices []ks.Service) func(ks.PodSpecer) (scorecard.Tes
 
 		if !isTargetedByService {
 			score.Grade = scorecard.GradeAllOK
+			score.Skipped = true
 			score.AddComment("", "The pod is not targeted by a service, skipping probe checks.", "")
 			return score, nil
 		}


### PR DESCRIPTION
```
RELNOTE: Pod Probes: correctly mark check as skipped when Pod is not targeted by a Service
```
