### PR TITLE
scorecard: fix enabling of optional tests with CLI flag

### DIFF
--- a/score/optional_test.go
+++ b/score/optional_test.go
@@ -1,0 +1,57 @@
+package score
+
+import (
+	"testing"
+
+	"github.com/zegl/kube-score/config"
+	ks "github.com/zegl/kube-score/domain"
+	"github.com/zegl/kube-score/scorecard"
+)
+
+func TestOptionalSkippedByDefault(t *testing.T) {
+	t.Parallel()
+	enabledOptionalTests := make(map[string]struct{})
+	wasSkipped(t, config.Configuration{
+		AllFiles:             []ks.NamedReader{testFile("pod-container-memory-requests.yaml")},
+		EnabledOptionalTests: enabledOptionalTests,
+	}, "Container Memory Requests Equal Limits")
+}
+
+func TestOptionalIgnoredAndEnabled(t *testing.T) {
+	t.Parallel()
+
+	enabledOptionalTests := make(map[string]struct{})
+	enabledOptionalTests["container-resource-requests-equal-limits"] = struct{}{}
+
+	ignoredTests := make(map[string]struct{})
+	ignoredTests["container-resource-requests-equal-limits"] = struct{}{}
+
+	wasSkipped(t, config.Configuration{
+		AllFiles:             []ks.NamedReader{testFile("pod-container-memory-requests.yaml")},
+		EnabledOptionalTests: enabledOptionalTests,
+		IgnoredTests:         ignoredTests,
+	}, "Container Memory Requests Equal Limits")
+}
+
+func TestOptionalRunCliFlagEnabledDefault(t *testing.T) {
+	t.Parallel()
+
+	enabledOptionalTests := make(map[string]struct{})
+	enabledOptionalTests["container-resource-requests-equal-limits"] = struct{}{}
+
+	testExpectedScoreWithConfig(t, config.Configuration{
+		AllFiles:             []ks.NamedReader{testFile("pod-container-memory-requests.yaml")},
+		EnabledOptionalTests: enabledOptionalTests,
+	}, "Container Memory Requests Equal Limits", scorecard.GradeCritical)
+}
+
+func TestOptionalRunAnnotationEnabled(t *testing.T) {
+	t.Parallel()
+
+	enabledOptionalTests := make(map[string]struct{})
+
+	testExpectedScoreWithConfig(t, config.Configuration{
+		AllFiles:             []ks.NamedReader{testFile("pod-container-memory-requests-annotation-optional.yaml")},
+		EnabledOptionalTests: enabledOptionalTests,
+	}, "Container Memory Requests Equal Limits", scorecard.GradeCritical)
+}

--- a/score/testdata/pod-container-memory-requests-annotation-optional.yaml
+++ b/score/testdata/pod-container-memory-requests-annotation-optional.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-test-1
+  namespace: testspace
+  labels:
+    app: foo-all-ok
+  annotations:
+    kube-score/enable: container-resource-requests-equal-limits
+spec:
+  containers:
+    - name: foobar
+      image: foo/bar:123
+      imagePullPolicy: Always
+      resources:
+        requests:
+          cpu: 1
+          memory: 1Gi
+          ephemeral-storage: 500Mi
+        limits:
+          cpu: 1
+          memory: 2Gi
+          ephemeral-storage: 500Mi
+      readinessProbe:
+        httpGet:
+          path: /ready
+          port: 8080
+      livenessProbe:
+        httpGet:
+          path: /live
+          port: 8080
+      securityContext:
+        privileged: False
+        runAsUser: 30000
+        runAsGroup: 30000
+        readOnlyRootFilesystem: True
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: foo-all-ok-netpol
+  namespace: testspace
+spec:
+  podSelector:
+    matchLabels:
+      app: foo-all-ok
+  policyTypes:
+    - Egress
+    - Ingress

--- a/score/testdata/pod-container-memory-requests.yaml
+++ b/score/testdata/pod-container-memory-requests.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-test-1
+  namespace: testspace
+  labels:
+    app: foo-all-ok
+spec:
+  containers:
+    - name: foobar
+      image: foo/bar:123
+      imagePullPolicy: Always
+      resources:
+        requests:
+          cpu: 1
+          memory: 1Gi
+          ephemeral-storage: 500Mi
+        limits:
+          cpu: 1
+          memory: 2Gi
+          ephemeral-storage: 500Mi
+      readinessProbe:
+        httpGet:
+          path: /ready
+          port: 8080
+      livenessProbe:
+        httpGet:
+          path: /live
+          port: 8080
+      securityContext:
+        privileged: False
+        runAsUser: 30000
+        runAsGroup: 30000
+        readOnlyRootFilesystem: True
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: foo-all-ok-netpol
+  namespace: testspace
+spec:
+  podSelector:
+    matchLabels:
+      app: foo-all-ok
+  policyTypes:
+    - Egress
+    - Ingress

--- a/scorecard/enabled.go
+++ b/scorecard/enabled.go
@@ -37,6 +37,11 @@ func (so *ScoredObject) isEnabled(check ks.Check, annotations, childAnnotations 
 		return true
 	}
 
+	// Enabled optional test from command line arguments
+	if _, ok := so.enabledOptionalTests[check.ID]; ok {
+		return true
+	}
+
 	// Optional checks are disabled unless explicitly allowed above
 	if check.Optional {
 		return false


### PR DESCRIPTION
Fixes #582

```
RELNOTE: fixes a bug where tests enabled with `--enable-optional-test` where still skipped
```
