### PR TITLE
all: extendable externally usable API

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,16 +5,11 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-
-	ks "github.com/zegl/kube-score/domain"
 )
 
-type Configuration struct {
-	AllFiles                              []ks.NamedReader
-	VerboseOutput                         int
+type RunConfiguration struct {
 	IgnoreContainerCpuLimitRequirement    bool
 	IgnoreContainerMemoryLimitRequirement bool
-	IgnoredTests                          map[string]struct{}
 	EnabledOptionalTests                  map[string]struct{}
 	UseIgnoreChecksAnnotation             bool
 	UseOptionalChecksAnnotation           bool

--- a/domain/kube-score.go
+++ b/domain/kube-score.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"io"
+
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 
 	appsv1 "k8s.io/api/apps/v1"

--- a/examples/custom_check.go
+++ b/examples/custom_check.go
@@ -1,0 +1,68 @@
+package examples
+
+import (
+	"bytes"
+	"io"
+	"strings"
+
+	"github.com/zegl/kube-score/config"
+	"github.com/zegl/kube-score/domain"
+	"github.com/zegl/kube-score/parser"
+	"github.com/zegl/kube-score/score"
+	"github.com/zegl/kube-score/score/checks"
+	"github.com/zegl/kube-score/scorecard"
+
+	v1 "k8s.io/api/apps/v1"
+)
+
+type namedReader struct {
+	io.Reader
+	name string
+}
+
+func (n namedReader) Name() string {
+	return n.name
+}
+
+// ExampleCheckObject shows how kube-score can be extended with a custom check function
+//
+// In this example, raw is a YAML encoded Kubernetes object
+func ExampleCheckObject(raw []byte) (*scorecard.Scorecard, error) {
+	parser, err := parser.New(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	reader := bytes.NewReader(raw)
+
+	// Parse all objects to read
+	allObjects, err := parser.ParseFiles(
+		[]domain.NamedReader{
+			namedReader{
+				Reader: reader,
+				name:   "input",
+			},
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Register check functions to run
+	checks := checks.New(nil)
+	checks.RegisterDeploymentCheck("custom-deployment-check", "A custom kube-score check function", customDeploymentCheck)
+
+	return score.Score(allObjects, checks, &config.RunConfiguration{})
+}
+
+func customDeploymentCheck(d v1.Deployment) (scorecard.TestScore, error) {
+	if strings.Contains(d.Name, "foo") {
+		return scorecard.TestScore{
+			Grade: scorecard.GradeCritical,
+			Comments: []scorecard.TestScoreComment{{
+				Summary: "Deployments names can not contian 'foo'",
+			}}}, nil
+	}
+
+	return scorecard.TestScore{Grade: scorecard.GradeAllOK}, nil
+}

--- a/examples/custom_check_test.go
+++ b/examples/custom_check_test.go
@@ -1,0 +1,64 @@
+package examples
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zegl/kube-score/scorecard"
+)
+
+func TestExampleCheckObjectAllOK(t *testing.T) {
+	card, err := ExampleCheckObject([]byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: example
+spec:
+    replicas: 10
+    template:
+    metadata:
+        labels:
+            app: foo
+    spec:
+        containers:
+        - name: foobar
+          image: foo:bar`))
+
+	assert.NoError(t, err)
+
+	assert.Len(t, *card, 1)
+
+	for _, v := range *card {
+		assert.Len(t, v.Checks, 1)
+		assert.Equal(t, "custom-deployment-check", v.Checks[0].Check.ID)
+		assert.Equal(t, scorecard.GradeAllOK, v.Checks[0].Grade)
+	}
+}
+
+func TestExampleCheckObjectErrorNameContainsFoo(t *testing.T) {
+	card, err := ExampleCheckObject([]byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: example-foo
+spec:
+    replicas: 10
+    template:
+    metadata:
+        labels:
+            app: foo
+    spec:
+        containers:
+        - name: foobar
+          image: foo:bar`))
+
+	assert.NoError(t, err)
+
+	assert.Len(t, *card, 1)
+
+	for _, v := range *card {
+		assert.Len(t, v.Checks, 1)
+		assert.Equal(t, "custom-deployment-check", v.Checks[0].Check.ID)
+		assert.Equal(t, scorecard.GradeCritical, v.Checks[0].Grade)
+	}
+}

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/zegl/kube-score/config"
 	ks "github.com/zegl/kube-score/domain"
 
 	"github.com/stretchr/testify/assert"
@@ -25,15 +24,15 @@ func TestParse(t *testing.T) {
 		},
 	}
 
-	parser, err := New()
+	parser, err := New(nil)
 	assert.NoError(t, err)
 
 	for _, tc := range cases {
 		fp, err := os.Open(tc.fname)
 		assert.Nil(t, err)
-		_, err = parser.ParseFiles(config.Configuration{
-			AllFiles: []ks.NamedReader{fp},
-		})
+		_, err = parser.ParseFiles(
+			[]ks.NamedReader{fp},
+		)
 		if tc.expected == nil {
 			assert.Nil(t, err)
 		} else {

--- a/renderer/sarif/sarif.go
+++ b/renderer/sarif/sarif.go
@@ -83,10 +83,10 @@ func Output(input *scorecard.Scorecard) io.Reader {
 		Conversion: sarif.Conversion{
 			Tool: sarif.Tool{
 				Driver: sarif.Driver{
-					Name:  "kube-score",				},
+					Name: "kube-score"},
 			},
 		},
-		Results: results,	
+		Results: results,
 	}
 	res := sarif.Sarif{
 		Runs:    []sarif.Run{run},

--- a/score/apps_test.go
+++ b/score/apps_test.go
@@ -108,20 +108,18 @@ func TestStatefulsetSelectorLabels(t *testing.T) {
 
 func TestStatefulsetTemplateIgnores(t *testing.T) {
 	t.Parallel()
-	skipped := wasSkipped(t, config.Configuration{
+	skipped := wasSkipped(t, []ks.NamedReader{testFile("statefulset-nested-ignores.yaml")}, nil, &config.RunConfiguration{
 		UseIgnoreChecksAnnotation:   true,
 		UseOptionalChecksAnnotation: true,
-		AllFiles:                    []ks.NamedReader{testFile("statefulset-nested-ignores.yaml")},
 	}, "Container Image Tag")
 	assert.True(t, skipped)
 }
 
 func TestStatefulsetTemplateIgnoresNotIgnoredWhenFlagDisabled(t *testing.T) {
 	t.Parallel()
-	skipped := wasSkipped(t, config.Configuration{
+	skipped := wasSkipped(t, []ks.NamedReader{testFile("statefulset-nested-ignores.yaml")}, nil, &config.RunConfiguration{
 		UseIgnoreChecksAnnotation:   false,
 		UseOptionalChecksAnnotation: true,
-		AllFiles:                    []ks.NamedReader{testFile("statefulset-nested-ignores.yaml")},
 	}, "Container Image Tag")
 	assert.False(t, skipped)
 }

--- a/score/checks/checks.go
+++ b/score/checks/checks.go
@@ -3,7 +3,6 @@ package checks
 import (
 	"strings"
 
-	"github.com/zegl/kube-score/config"
 	ks "github.com/zegl/kube-score/domain"
 	"github.com/zegl/kube-score/scorecard"
 	appsv1 "k8s.io/api/apps/v1"
@@ -11,7 +10,14 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 )
 
-func New(cnf config.Configuration) *Checks {
+type Config struct {
+	IgnoredTests map[string]struct{}
+}
+
+func New(cnf *Config) *Checks {
+	if cnf == nil {
+		cnf = &Config{}
+	}
 	return &Checks{
 		cnf: cnf,
 
@@ -71,7 +77,7 @@ type Checks struct {
 	horizontalPodAutoscalers map[string]GenCheck[ks.HpaTargeter]
 	poddisruptionbudgets     map[string]GenCheck[ks.PodDisruptionBudget]
 
-	cnf config.Configuration
+	cnf *Config
 }
 
 func (c Checks) isEnabled(check ks.Check) bool {

--- a/score/container/container.go
+++ b/score/container/container.go
@@ -4,15 +4,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/zegl/kube-score/config"
 	ks "github.com/zegl/kube-score/domain"
 	"github.com/zegl/kube-score/score/checks"
 	"github.com/zegl/kube-score/scorecard"
 	corev1 "k8s.io/api/core/v1"
 )
 
-func Register(allChecks *checks.Checks, cnf config.Configuration) {
-	allChecks.RegisterPodCheck("Container Resources", `Makes sure that all pods have resource limits and requests set. The --ignore-container-cpu-limit flag can be used to disable the requirement of having a CPU limit`, containerResources(!cnf.IgnoreContainerCpuLimitRequirement, !cnf.IgnoreContainerMemoryLimitRequirement))
+func Register(allChecks *checks.Checks, ignoreContainerCpuLimitRequirement, ignoreContainerMemoryLimitRequirement bool) {
+	allChecks.RegisterPodCheck("Container Resources", `Makes sure that all pods have resource limits and requests set. The --ignore-container-cpu-limit flag can be used to disable the requirement of having a CPU limit`, containerResources(!ignoreContainerCpuLimitRequirement, !ignoreContainerMemoryLimitRequirement))
 	allChecks.RegisterOptionalPodCheck("Container Resource Requests Equal Limits", `Makes sure that all pods have the same requests as limits on resources set.`, containerResourceRequestsEqualLimits)
 	allChecks.RegisterOptionalPodCheck("Container CPU Requests Equal Limits", `Makes sure that all pods have the same CPU requests as limits set.`, containerCPURequestsEqualLimits)
 	allChecks.RegisterOptionalPodCheck("Container Memory Requests Equal Limits", `Makes sure that all pods have the same memory requests as limits set.`, containerMemoryRequestsEqualLimits)

--- a/score/deployment_test.go
+++ b/score/deployment_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/zegl/kube-score/config"
 	ks "github.com/zegl/kube-score/domain"
 	"github.com/zegl/kube-score/scorecard"
 )
@@ -16,9 +15,9 @@ func TestServiceTargetsDeploymentStrategyRolling(t *testing.T) {
 
 func TestServiceNotTargetsDeploymentStrategyNotRelevant(t *testing.T) {
 	t.Parallel()
-	skipped := wasSkipped(t, config.Configuration{
-		AllFiles: []ks.NamedReader{testFile("service-not-target-deployment.yaml")},
-	}, "Deployment Strategy")
+	skipped := wasSkipped(t,
+		[]ks.NamedReader{testFile("service-not-target-deployment.yaml")}, nil, nil,
+		"Deployment Strategy")
 	assert.True(t, skipped)
 }
 
@@ -39,13 +38,12 @@ func TestServiceTargetsDeploymentReplicasOk(t *testing.T) {
 
 func TestServiceNotTargetsDeploymentReplicasNotRelevant(t *testing.T) {
 	t.Parallel()
-	assert.True(t, wasSkipped(t, config.Configuration{
-		AllFiles: []ks.NamedReader{testFile("service-not-target-deployment.yaml")},
-	}, "Deployment Replicas"))
+	assert.True(t, wasSkipped(t,
+		[]ks.NamedReader{testFile("service-not-target-deployment.yaml")}, nil, nil,
+		"Deployment Replicas"))
 
-	summaries := getSummaries(t, config.Configuration{
-		AllFiles: []ks.NamedReader{testFile("service-not-target-deployment.yaml")},
-	}, "Deployment Replicas")
+	summaries := getSummaries(t, []ks.NamedReader{testFile("service-not-target-deployment.yaml")}, nil, nil,
+		"Deployment Replicas")
 	assert.Contains(t, summaries, "Skipped as the Deployment is not targeted by service")
 }
 
@@ -56,12 +54,11 @@ func TestServiceTargetsDeploymentReplicasNok(t *testing.T) {
 
 func TestHPATargetsDeployment(t *testing.T) {
 	t.Parallel()
-	assert.True(t, wasSkipped(t, config.Configuration{
-		AllFiles: []ks.NamedReader{testFile("hpa-target-deployment.yaml")},
-	}, "Deployment Replicas"))
+	assert.True(t, wasSkipped(t,
+		[]ks.NamedReader{testFile("hpa-target-deployment.yaml")}, nil, nil,
+		"Deployment Replicas"))
 
-	summaries := getSummaries(t, config.Configuration{
-		AllFiles: []ks.NamedReader{testFile("hpa-target-deployment.yaml")},
-	}, "Deployment Replicas")
+	summaries := getSummaries(t, []ks.NamedReader{testFile("hpa-target-deployment.yaml")}, nil, nil,
+		"Deployment Replicas")
 	assert.Contains(t, summaries, "Skipped as the Deployment is controlled by a HorizontalPodAutoscaler")
 }

--- a/score/filelocation_test.go
+++ b/score/filelocation_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestFileLocationHelm(t *testing.T) {
-	sc, err := testScore(config.Configuration{
-		AllFiles:          []ks.NamedReader{testFile("linenumbers-helm.yaml")},
+	sc, err := testScore([]ks.NamedReader{testFile("linenumbers-helm.yaml")}, nil, &config.RunConfiguration{
 		KubernetesVersion: config.Semver{Major: 1, Minor: 18},
 	})
 	assert.Nil(t, err)
@@ -23,8 +22,7 @@ func TestFileLocationHelm(t *testing.T) {
 }
 
 func TestFileLocation(t *testing.T) {
-	sc, err := testScore(config.Configuration{
-		AllFiles:          []ks.NamedReader{testFile("linenumbers.yaml")},
+	sc, err := testScore([]ks.NamedReader{testFile("linenumbers.yaml")}, nil, &config.RunConfiguration{
 		KubernetesVersion: config.Semver{Major: 1, Minor: 18},
 	})
 	assert.Nil(t, err)

--- a/score/optional_test.go
+++ b/score/optional_test.go
@@ -5,14 +5,14 @@ import (
 
 	"github.com/zegl/kube-score/config"
 	ks "github.com/zegl/kube-score/domain"
+	"github.com/zegl/kube-score/score/checks"
 	"github.com/zegl/kube-score/scorecard"
 )
 
 func TestOptionalSkippedByDefault(t *testing.T) {
 	t.Parallel()
 	enabledOptionalTests := make(map[string]struct{})
-	wasSkipped(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-container-memory-requests.yaml")},
+	wasSkipped(t, []ks.NamedReader{testFile("pod-container-memory-requests.yaml")}, nil, &config.RunConfiguration{
 		EnabledOptionalTests: enabledOptionalTests,
 	}, "Container Memory Requests Equal Limits")
 }
@@ -26,10 +26,10 @@ func TestOptionalIgnoredAndEnabled(t *testing.T) {
 	ignoredTests := make(map[string]struct{})
 	ignoredTests["container-resource-requests-equal-limits"] = struct{}{}
 
-	wasSkipped(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-container-memory-requests.yaml")},
+	wasSkipped(t, []ks.NamedReader{testFile("pod-container-memory-requests.yaml")}, &checks.Config{
+		IgnoredTests: ignoredTests,
+	}, &config.RunConfiguration{
 		EnabledOptionalTests: enabledOptionalTests,
-		IgnoredTests:         ignoredTests,
 	}, "Container Memory Requests Equal Limits")
 }
 
@@ -39,10 +39,10 @@ func TestOptionalRunCliFlagEnabledDefault(t *testing.T) {
 	enabledOptionalTests := make(map[string]struct{})
 	enabledOptionalTests["container-resource-requests-equal-limits"] = struct{}{}
 
-	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-container-memory-requests.yaml")},
-		EnabledOptionalTests: enabledOptionalTests,
-	}, "Container Memory Requests Equal Limits", scorecard.GradeCritical)
+	testExpectedScoreWithConfig(t,
+		[]ks.NamedReader{testFile("pod-container-memory-requests.yaml")}, nil, &config.RunConfiguration{
+			EnabledOptionalTests: enabledOptionalTests,
+		}, "Container Memory Requests Equal Limits", scorecard.GradeCritical)
 }
 
 func TestOptionalRunAnnotationEnabled(t *testing.T) {
@@ -50,8 +50,8 @@ func TestOptionalRunAnnotationEnabled(t *testing.T) {
 
 	enabledOptionalTests := make(map[string]struct{})
 
-	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-container-memory-requests-annotation-optional.yaml")},
-		EnabledOptionalTests: enabledOptionalTests,
-	}, "Container Memory Requests Equal Limits", scorecard.GradeCritical)
+	testExpectedScoreWithConfig(t, []ks.NamedReader{testFile("pod-container-memory-requests-annotation-optional.yaml")}, nil,
+		&config.RunConfiguration{
+			EnabledOptionalTests: enabledOptionalTests,
+		}, "Container Memory Requests Equal Limits", scorecard.GradeCritical)
 }

--- a/score/security_test.go
+++ b/score/security_test.go
@@ -15,8 +15,7 @@ func TestContainerSeccompMissing(t *testing.T) {
 	structMap := make(map[string]struct{})
 	structMap["container-seccomp-profile"] = struct{}{}
 
-	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-seccomp-no-annotation.yaml")},
+	testExpectedScoreWithConfig(t, []ks.NamedReader{testFile("pod-seccomp-no-annotation.yaml")}, nil, &config.RunConfiguration{
 		EnabledOptionalTests: structMap,
 	}, "Container Seccomp Profile", scorecard.GradeWarning)
 
@@ -24,9 +23,7 @@ func TestContainerSeccompMissing(t *testing.T) {
 
 func TestContainerSeccompMissingNotRunByDefault(t *testing.T) {
 	t.Parallel()
-	skipped := wasSkipped(t, config.Configuration{
-		AllFiles: []ks.NamedReader{testFile("pod-seccomp-no-annotation.yaml")},
-	}, "Container Seccomp Profile")
+	skipped := wasSkipped(t, []ks.NamedReader{testFile("pod-seccomp-no-annotation.yaml")}, nil, nil, "Container Seccomp Profile")
 	assert.True(t, skipped)
 }
 
@@ -36,8 +33,8 @@ func TestContainerSeccompAllGood(t *testing.T) {
 	structMap := make(map[string]struct{})
 	structMap["container-seccomp-profile"] = struct{}{}
 
-	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-seccomp-annotated.yaml")},
+	testExpectedScoreWithConfig(t, []ks.NamedReader{testFile("pod-seccomp-annotated.yaml")}, nil, &config.RunConfiguration{
+
 		EnabledOptionalTests: structMap,
 	}, "Container Seccomp Profile", scorecard.GradeAllOK)
 }
@@ -45,8 +42,7 @@ func TestContainerSeccompAllGood(t *testing.T) {
 func TestContainerSeccompAllGoodAnnotation(t *testing.T) {
 	t.Parallel()
 
-	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:                    []ks.NamedReader{testFile("pod-seccomp-annotated-annotation-optional.yaml")},
+	testExpectedScoreWithConfig(t, []ks.NamedReader{testFile("pod-seccomp-annotated-annotation-optional.yaml")}, nil, &config.RunConfiguration{
 		UseOptionalChecksAnnotation: true,
 	}, "Container Seccomp Profile", scorecard.GradeAllOK)
 }
@@ -55,8 +51,7 @@ func TestContainerSecurityContextUserGroupIDAllGood(t *testing.T) {
 	t.Parallel()
 	structMap := make(map[string]struct{})
 	structMap["container-security-context-user-group-id"] = struct{}{}
-	c := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-security-context-all-good.yaml")},
+	c := testExpectedScoreWithConfig(t, []ks.NamedReader{testFile("pod-security-context-all-good.yaml")}, nil, &config.RunConfiguration{
 		EnabledOptionalTests: structMap,
 	}, "Container Security Context User Group ID", scorecard.GradeAllOK)
 	assert.Empty(t, c)
@@ -66,8 +61,8 @@ func TestContainerSecurityContextUserGroupIDLowGroup(t *testing.T) {
 	t.Parallel()
 	optionalChecks := make(map[string]struct{})
 	optionalChecks["container-security-context-user-group-id"] = struct{}{}
-	comments := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-security-context-low-group-id.yaml")},
+	comments := testExpectedScoreWithConfig(t, []ks.NamedReader{testFile("pod-security-context-low-group-id.yaml")}, nil, &config.RunConfiguration{
+
 		EnabledOptionalTests: optionalChecks,
 	}, "Container Security Context User Group ID", scorecard.GradeCritical)
 	assert.Contains(t, comments, scorecard.TestScoreComment{
@@ -81,8 +76,7 @@ func TestContainerSecurityContextUserGroupIDLowUser(t *testing.T) {
 	t.Parallel()
 	optionalChecks := make(map[string]struct{})
 	optionalChecks["container-security-context-user-group-id"] = struct{}{}
-	comments := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-security-context-low-user-id.yaml")},
+	comments := testExpectedScoreWithConfig(t, []ks.NamedReader{testFile("pod-security-context-low-user-id.yaml")}, nil, &config.RunConfiguration{
 		EnabledOptionalTests: optionalChecks,
 	}, "Container Security Context User Group ID", scorecard.GradeCritical)
 	assert.Contains(t, comments, scorecard.TestScoreComment{
@@ -96,8 +90,8 @@ func TestContainerSecurityContextUserGroupIDNoSecurityContext(t *testing.T) {
 	t.Parallel()
 	optionalChecks := make(map[string]struct{})
 	optionalChecks["container-security-context-user-group-id"] = struct{}{}
-	comments := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-security-context-nosecuritycontext.yaml")},
+	comments := testExpectedScoreWithConfig(t, []ks.NamedReader{testFile("pod-security-context-nosecuritycontext.yaml")}, nil, &config.RunConfiguration{
+
 		EnabledOptionalTests: optionalChecks,
 	}, "Container Security Context User Group ID", scorecard.GradeCritical)
 	assert.Contains(t, comments, scorecard.TestScoreComment{
@@ -111,8 +105,7 @@ func TestContainerSecurityContextPrivilegedAllGood(t *testing.T) {
 	t.Parallel()
 	structMap := make(map[string]struct{})
 	structMap["container-security-context-privileged"] = struct{}{}
-	c := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-security-context-all-good.yaml")},
+	c := testExpectedScoreWithConfig(t, []ks.NamedReader{testFile("pod-security-context-all-good.yaml")}, nil, &config.RunConfiguration{
 		EnabledOptionalTests: structMap,
 	}, "Container Security Context Privileged", scorecard.GradeAllOK)
 	assert.Empty(t, c)
@@ -122,8 +115,7 @@ func TestContainerSecurityContextPrivilegedPrivileged(t *testing.T) {
 	t.Parallel()
 	optionalChecks := make(map[string]struct{})
 	optionalChecks["container-security-context-privileged"] = struct{}{}
-	comments := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-security-context-privileged.yaml")},
+	comments := testExpectedScoreWithConfig(t, []ks.NamedReader{testFile("pod-security-context-privileged.yaml")}, nil, &config.RunConfiguration{
 		EnabledOptionalTests: optionalChecks,
 	}, "Container Security Context Privileged", scorecard.GradeCritical)
 	assert.Contains(t, comments, scorecard.TestScoreComment{
@@ -137,8 +129,7 @@ func TestContainerSecurityContextReadOnlyRootFilesystemAllGood(t *testing.T) {
 	t.Parallel()
 	structMap := make(map[string]struct{})
 	structMap["container-security-context-readonlyrootfilesystem"] = struct{}{}
-	c := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-security-context-all-good.yaml")},
+	c := testExpectedScoreWithConfig(t, []ks.NamedReader{testFile("pod-security-context-all-good.yaml")}, nil, &config.RunConfiguration{
 		EnabledOptionalTests: structMap,
 	}, "Container Security Context ReadOnlyRootFilesystem", scorecard.GradeAllOK)
 	assert.Empty(t, c)
@@ -148,8 +139,7 @@ func TestContainerSecurityContextReadOnlyRootFilesystemWriteable(t *testing.T) {
 	t.Parallel()
 	optionalChecks := make(map[string]struct{})
 	optionalChecks["container-security-context-readonlyrootfilesystem"] = struct{}{}
-	comments := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-security-context-writeablerootfilesystem.yaml")},
+	comments := testExpectedScoreWithConfig(t, []ks.NamedReader{testFile("pod-security-context-writeablerootfilesystem.yaml")}, nil, &config.RunConfiguration{
 		EnabledOptionalTests: optionalChecks,
 	}, "Container Security Context ReadOnlyRootFilesystem", scorecard.GradeCritical)
 	assert.Contains(t, comments, scorecard.TestScoreComment{
@@ -163,8 +153,7 @@ func TestContainerSecurityContextReadOnlyRootFilesystemNoSecurityContext(t *test
 	t.Parallel()
 	optionalChecks := make(map[string]struct{})
 	optionalChecks["container-security-context-readonlyrootfilesystem"] = struct{}{}
-	comments := testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:             []ks.NamedReader{testFile("pod-security-context-nosecuritycontext.yaml")},
+	comments := testExpectedScoreWithConfig(t, []ks.NamedReader{testFile("pod-security-context-nosecuritycontext.yaml")}, nil, &config.RunConfiguration{
 		EnabledOptionalTests: optionalChecks,
 	}, "Container Security Context ReadOnlyRootFilesystem", scorecard.GradeCritical)
 	assert.Contains(t, comments, scorecard.TestScoreComment{

--- a/score/stable_version_test.go
+++ b/score/stable_version_test.go
@@ -15,16 +15,14 @@ func TestStatefulSetAppsv1beta1(t *testing.T) {
 
 func TestStatefulSetAppsv1beta1Kubernetes1dot4(t *testing.T) {
 	t.Parallel()
-	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:          []ks.NamedReader{testFile("statefulset-appsv1beta1.yaml")},
+	testExpectedScoreWithConfig(t, []ks.NamedReader{testFile("statefulset-appsv1beta1.yaml")}, nil, &config.RunConfiguration{
 		KubernetesVersion: config.Semver{Major: 1, Minor: 4},
 	}, "Stable version", scorecard.GradeAllOK)
 }
 
 func TestStatefulSetAppsv1beta1Kubernetes1dot18(t *testing.T) {
 	t.Parallel()
-	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:          []ks.NamedReader{testFile("statefulset-appsv1beta1.yaml")},
+	testExpectedScoreWithConfig(t, []ks.NamedReader{testFile("statefulset-appsv1beta1.yaml")}, nil, &config.RunConfiguration{
 		KubernetesVersion: config.Semver{Major: 1, Minor: 18},
 	}, "Stable version", scorecard.GradeWarning)
 }
@@ -71,8 +69,7 @@ func TestCronJobBatchv1beta1(t *testing.T) {
 
 func TestCronJobBatchv1beta1Kubernetes1dot21(t *testing.T) {
 	t.Parallel()
-	testExpectedScoreWithConfig(t, config.Configuration{
-		AllFiles:          []ks.NamedReader{testFile("cronjob-batchv1beta1.yaml")},
+	testExpectedScoreWithConfig(t, []ks.NamedReader{testFile("cronjob-batchv1beta1.yaml")}, nil, &config.RunConfiguration{
 		KubernetesVersion: config.Semver{Major: 1, Minor: 21},
 	}, "Stable version", scorecard.GradeWarning)
 }

--- a/scorecard/scorecard.go
+++ b/scorecard/scorecard.go
@@ -25,7 +25,11 @@ func New() Scorecard {
 	return make(Scorecard)
 }
 
-func (s Scorecard) NewObject(typeMeta metav1.TypeMeta, objectMeta metav1.ObjectMeta, cnf config.Configuration) *ScoredObject {
+func (s Scorecard) NewObject(typeMeta metav1.TypeMeta, objectMeta metav1.ObjectMeta, cnf *config.RunConfiguration) *ScoredObject {
+	if cnf == nil {
+		cnf = &config.RunConfiguration{}
+	}
+
 	o := &ScoredObject{
 		TypeMeta:   typeMeta,
 		ObjectMeta: objectMeta,


### PR DESCRIPTION
Refactor/rewrite the Go API (not previously considered to be stable) to be extendable with custom checks written in Go, and to make the API easier to consume.

The API is not yet considered to be stable, but this is a good step in that direction.

Fixes #534 