### PR TITLE
Feat/split container probes identical check

### DIFF
--- a/README_CHECKS.md
+++ b/README_CHECKS.md
@@ -22,6 +22,7 @@
 | pod-networkpolicy | Pod | Makes sure that all Pods are targeted by a NetworkPolicy | default |
 | networkpolicy-targets-pod | NetworkPolicy | Makes sure that all NetworkPolicies targets at least one Pod | default |
 | pod-probes | Pod | Makes sure that all Pods have safe probe configurations | default |
+| pod-probes-identical | Pod | Makes sure that readiness and liveness probes are not identical | default |
 | container-security-context-user-group-id | Pod | Makes sure that all pods have a security context with valid UID and GID set  | default |
 | container-security-context-privileged | Pod | Makes sure that all pods have a unprivileged security context set | default |
 | container-security-context-readonlyrootfilesystem | Pod | Makes sure that all pods have a security context with read only filesystem set | default |

--- a/score/probe_test.go
+++ b/score/probe_test.go
@@ -24,21 +24,21 @@ func TestProbesPodMissingReady(t *testing.T) {
 
 func TestProbesPodIdenticalHTTP(t *testing.T) {
 	t.Parallel()
-	comments := testExpectedScore(t, "pod-probes-identical-http.yaml", "Pod Probes", scorecard.GradeCritical)
+	comments := testExpectedScore(t, "pod-probes-identical-http.yaml", "Pod Probes Identical", scorecard.GradeCritical)
 	assert.Len(t, comments, 1)
 	assert.Equal(t, "Container has the same readiness and liveness probe", comments[0].Summary)
 }
 
 func TestProbesPodIdenticalTCP(t *testing.T) {
 	t.Parallel()
-	comments := testExpectedScore(t, "pod-probes-identical-tcp.yaml", "Pod Probes", scorecard.GradeCritical)
+	comments := testExpectedScore(t, "pod-probes-identical-tcp.yaml", "Pod Probes Identical", scorecard.GradeCritical)
 	assert.Len(t, comments, 1)
 	assert.Equal(t, "Container has the same readiness and liveness probe", comments[0].Summary)
 }
 
 func TestProbesPodIdenticalExec(t *testing.T) {
 	t.Parallel()
-	comments := testExpectedScore(t, "pod-probes-identical-exec.yaml", "Pod Probes", scorecard.GradeCritical)
+	comments := testExpectedScore(t, "pod-probes-identical-exec.yaml", "Pod Probes Identical", scorecard.GradeCritical)
 	assert.Len(t, comments, 1)
 	assert.Equal(t, "Container has the same readiness and liveness probe", comments[0].Summary)
 }


### PR DESCRIPTION

```
RELNOTE: separating test cases into separate validation rules, this will add the ability to exclude validations more granularly
```
