### PR TITLE
[FEATURE] Add `pre-commit` hooks for running `kube-score`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,29 @@
+---
+- id: "kube-score"
+  name: "Run kube-score"
+  description:
+    "This hook installs and runs `kube-score` to perform static code analysis of your Kubernetes object definitions"
+  language: "golang"
+  types:
+    - "yaml"
+  entry: "kube-score score"
+
+- id: "kube-score-system"
+  name: "Run kube-score from system"
+  description: >-
+    This hook runs `kube-score` installed on your system
+    to perform static code analysis of your Kubernetes object definitions
+  language: "system"
+  entry: "kube-score score"
+  types:
+    - "yaml"
+
+- id: "kube-score-container"
+  name: "Run kube-score via container"
+  description:
+    "This hook runs `kube-score` via container to perform static code analysis of your Kubernetes object definitions"
+  language: "docker_image"
+  types:
+    - "yaml"
+  entry: "zegl/kube-score:latest score"
+...

--- a/README.md
+++ b/README.md
@@ -118,6 +118,26 @@ Flags for score:
   -v, --verbose count                       Enable verbose output, can be set multiple times for increased verbosity.
 ```
 
+### Example with `pre-commit`
+
+`kube-score` can be run as [`pre-commit`](https://pre-commit.com/) hook.
+Add the following to your `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: "https://github.com/zegl/kube-score"
+    rev: "<LATEST_VERSION>"
+    hooks:
+      - id: "kube-score"
+        files: "path/to/my/manifests/.*\\.ya?ml"
+```
+
+The following hook id's are provided:
+
+- `kube-score`: Installs and runs `kube-score`
+- `kube-score-system`: Runs `kube-score` installed on your system
+- `kube-score-container`: Runs `kube-score` via container
+
 ### Ignoring a test
 
 Tests can be ignored in the whole run of the program, with the `--ignore-test` flag.


### PR DESCRIPTION
Resolves #658

<!--
    Optional: Add this change to the release notes by adding a RELNOTE comment
    If this shouldn't appear in the notes, simply remove this.
-->

```
RELNOTE: Add `pre-commit` hooks for running `kube-score`
```
