### PR TITLE
prepare for `apimachinery` >= 0.34

### DIFF
--- a/score/internal/labelselector.go
+++ b/score/internal/labelselector.go
@@ -14,6 +14,11 @@ func (l MapLabels) Get(key string) string {
 	return l[key]
 }
 
+func (l MapLabels) Lookup(label string) (value string, exists bool) {
+	value, exists = l[label]
+	return value, exists
+}
+
 func LabelSelectorMatchesLabels(selectorLabels map[string]string, labels map[string]string) bool {
 	labelSelector := &metav1.LabelSelector{
 		MatchLabels: selectorLabels,


### PR DESCRIPTION
`apimachinery` has defined a [Lookup-Method](https://pkg.go.dev/k8s.io/apimachinery@v0.34.0/pkg/labels#Labels) for the `Labels` interface starting from `0.34.0`.

We are using kubescore as a dependency in [our go code](https://github.com/steadybit/extension-kubernetes) and want to use the latest version of `apimachinery`.

This PR is adding this method (without increasing the version of `apimachinery`)

This would also make dependabot happy (#675)